### PR TITLE
Genre search, lyrics, enriched recommendations, Now Playing redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ MassDroid includes a local recommendation engine that learns your listening habi
 - **MMR Re-ranking** : Prevents genre clustering by penalizing items too similar to already-selected ones.
 - **Genre Adjacency** : Built from co-occurrence in your play history to discover genres you might enjoy.
 - **Exploration Budget** : 70% top matches, 20% adjacent genres, 10% wildcard for serendipitous discovery.
-- **Last.fm Genre Fallback** : When your music provider has no genre data, the app queries Last.fm artist tags (optional, cached locally for 30 days).
+- **Last.fm Genre Fallback** : When your music provider has no genre data, the app queries Last.fm artist tags (optional, cached locally for 30 days). Enriched genres are used across the entire app: recommendations, Smart Mix, genre radio, and library search.
 
 All recommendation data stays on-device in a local Room database. Nothing is sent to external services.
 
 ## Features
 
 - **Discover Home** : Dynamic recommendation sections with recently played, top picks, genre radio, and Smart Mix
-- **Library Browsing** : Artists, Albums, Tracks, Playlists with search, sort, and grid/list views
+- **Library Browsing** : Artists, Albums, Tracks, Playlists with search, sort, and grid/list views. Genre-based search finds artists, albums, and tracks by genre when your library has been enriched with Last.fm tags.
 - **Artist & Album Detail** : Rich detail views with descriptions, genres, similar artists, and now-playing indicators
 - **Player Controls** : Play, pause, skip, seek, volume, shuffle, repeat across all MA players
-- **Now Playing** : Full-screen player with album art, seek bar, favorite toggle, and artist blocking
+- **Now Playing** : Full-screen player with album art, seek bar, favorite toggle, lyrics, and artist blocking
 - **Queue Management** : View, drag-to-reorder, transfer between players, and manage the playback queue with action sheets
 - **Favorites** : Mark artists, albums, tracks, and playlists as favorites, filter library by favorites
 - **Phone as Speaker** : Sendspin protocol turns your phone into a Music Assistant player. Audio streams as Opus frames over WebSocket, decoded and played through your phone speaker or headphones.

--- a/app/src/main/java/net/asksakis/massdroidv2/data/database/PlayHistoryDao.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/data/database/PlayHistoryDao.kt
@@ -44,6 +44,13 @@ interface PlayHistoryDao {
     @Query("SELECT genre_name FROM artist_genres WHERE artist_uri = :artistUri")
     suspend fun getGenresForArtist(artistUri: String): List<String>
 
+    @Query("""
+        SELECT DISTINCT ag.artist_uri FROM artist_genres ag
+        WHERE ag.genre_name LIKE '%' || :query || '%'
+        LIMIT :limit
+    """)
+    suspend fun searchArtistUrisByGenre(query: String, limit: Int = 30): List<String>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertLastFmTags(tags: LastFmArtistTagsEntity)
 

--- a/app/src/main/java/net/asksakis/massdroidv2/data/lastfm/LastFmGenreResolver.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/data/lastfm/LastFmGenreResolver.kt
@@ -75,7 +75,7 @@ class LastFmGenreResolver @Inject constructor(
         )
 
         private fun normalizeTag(tag: String): String =
-            tag.lowercase().trim().replace('-', ' ')
+            net.asksakis.massdroidv2.domain.recommendation.normalizeGenre(tag).replace('-', ' ')
     }
 
     suspend fun resolve(artistName: String): List<String> {

--- a/app/src/main/java/net/asksakis/massdroidv2/data/lastfm/LastFmLibraryEnricher.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/data/lastfm/LastFmLibraryEnricher.kt
@@ -1,0 +1,91 @@
+package net.asksakis.massdroidv2.data.lastfm
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import net.asksakis.massdroidv2.data.database.ArtistEntity
+import net.asksakis.massdroidv2.data.database.ArtistGenreEntity
+import net.asksakis.massdroidv2.data.database.GenreEntity
+import net.asksakis.massdroidv2.data.database.PlayHistoryDao
+import net.asksakis.massdroidv2.domain.model.Artist
+import net.asksakis.massdroidv2.domain.recommendation.canonicalKey
+import java.util.concurrent.ConcurrentLinkedQueue
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LastFmLibraryEnricher @Inject constructor(
+    private val lastFmGenreResolver: LastFmGenreResolver,
+    private val dao: PlayHistoryDao
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var enrichJob: Job? = null
+    private val enrichedNames = mutableSetOf<String>()
+    private val pendingQueue = ConcurrentLinkedQueue<Artist>()
+
+    @Suppress("TooGenericExceptionCaught")
+    fun enrichInBackground(artists: List<Artist>) {
+        val newArtists = artists.filter { it.name.trim().let { n -> n.isNotBlank() && n !in enrichedNames } }
+        if (newArtists.isEmpty()) return
+        pendingQueue.addAll(newArtists)
+        if (enrichJob?.isActive == true) return
+        enrichJob = scope.launch {
+            try {
+                processQueue()
+            } catch (e: Exception) {
+                Log.e(TAG, "Background enrichment failed", e)
+            }
+        }
+    }
+
+    private suspend fun processQueue() {
+        var enriched = 0
+        var total = 0
+        while (true) {
+            val artist = pendingQueue.poll() ?: break
+            val name = artist.name.trim()
+            if (name.isBlank() || name in enrichedNames) continue
+            total++
+            try {
+                val cached = dao.getLastFmTags(name)
+                if (cached != null) {
+                    enrichedNames += name
+                    writeArtistGenres(artist, cached.tags.split(",").filter { it.isNotBlank() })
+                    continue
+                }
+                val tags = lastFmGenreResolver.resolve(name)
+                enrichedNames += name
+                if (tags.isNotEmpty()) {
+                    writeArtistGenres(artist, tags)
+                    enriched++
+                }
+                delay(RATE_LIMIT_MS)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to enrich ${artist.name}: ${e.message}")
+            }
+        }
+        if (total > 0) {
+            Log.d(TAG, "Background enrichment done: $enriched/$total enriched")
+        }
+    }
+
+    private suspend fun writeArtistGenres(artist: Artist, genres: List<String>) {
+        val artistUri = artist.canonicalKey() ?: return
+        dao.insertArtist(ArtistEntity(uri = artistUri, name = artist.name))
+        for (genre in genres) {
+            if (genre.isNotBlank()) {
+                dao.insertGenre(GenreEntity(name = genre))
+                dao.insertArtistGenre(ArtistGenreEntity(artistUri = artistUri, genreName = genre))
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "LastFmEnricher"
+        private const val RATE_LIMIT_MS = 200L
+    }
+}

--- a/app/src/main/java/net/asksakis/massdroidv2/data/lyrics/LyricsProvider.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/data/lyrics/LyricsProvider.kt
@@ -1,0 +1,76 @@
+package net.asksakis.massdroidv2.data.lyrics
+
+import android.util.Log
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import net.asksakis.massdroidv2.data.websocket.MaCommands
+import net.asksakis.massdroidv2.data.websocket.MaWebSocketClient
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "LyricsProvider"
+
+@Singleton
+class LyricsProvider @Inject constructor(
+    private val wsClient: MaWebSocketClient
+) {
+    data class LyricsResult(val plainText: String?, val syncedLrc: String?)
+    data class LrcLine(val timeMs: Long, val text: String)
+
+    private var cachedTrackUri: String? = null
+    private var cachedResult: LyricsResult? = null
+
+    suspend fun getLyrics(itemId: String, provider: String, trackUri: String): LyricsResult {
+        cachedResult?.let { if (trackUri == cachedTrackUri) return it }
+
+        val trackJson = wsClient.sendCommand(
+            MaCommands.Music.TRACKS_GET,
+            buildJsonObject {
+                put("item_id", itemId)
+                put("provider_instance_id_or_domain", provider)
+            }
+        ) ?: return LyricsResult(null, null).also { cache(trackUri, it) }
+
+        val result = wsClient.sendCommand(
+            MaCommands.Metadata.GET_TRACK_LYRICS,
+            buildJsonObject { put("track", trackJson) }
+        )
+
+        val arr = try {
+            result?.jsonArray
+        } catch (e: Exception) {
+            Log.w(TAG, "Unexpected lyrics response format: ${e.message}")
+            null
+        } ?: return LyricsResult(null, null).also { cache(trackUri, it) }
+
+        val plain = arr.getOrNull(0)?.takeIf { it.jsonPrimitive.isString }?.jsonPrimitive?.content
+        val lrc = arr.getOrNull(1)?.takeIf { it.jsonPrimitive.isString }?.jsonPrimitive?.content
+        return LyricsResult(plain, lrc).also { cache(trackUri, it) }
+    }
+
+    fun clearCache() {
+        cachedTrackUri = null
+        cachedResult = null
+    }
+
+    private fun cache(uri: String, result: LyricsResult) {
+        cachedTrackUri = uri
+        cachedResult = result
+    }
+
+    companion object {
+        fun parseLrc(lrc: String): List<LrcLine> {
+            val regex = Regex("""\[(\d+):(\d+)[.:](\d+)](.*)""")
+            return lrc.lines().mapNotNull { line ->
+                regex.find(line)?.let { match ->
+                    val min = match.groupValues[1].toLong()
+                    val sec = match.groupValues[2].toLong()
+                    val ms = match.groupValues[3].padEnd(3, '0').take(3).toLong()
+                    LrcLine((min * 60 + sec) * 1000 + ms, match.groupValues[4].trim())
+                }
+            }.sortedBy { it.timeMs }
+        }
+    }
+}

--- a/app/src/main/java/net/asksakis/massdroidv2/data/repository/PlayHistoryRepositoryImpl.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/data/repository/PlayHistoryRepositoryImpl.kt
@@ -13,6 +13,7 @@ import net.asksakis.massdroidv2.data.database.TrackEntity
 import net.asksakis.massdroidv2.data.database.TrackGenreEntity
 import net.asksakis.massdroidv2.domain.model.Track
 import net.asksakis.massdroidv2.domain.recommendation.MediaIdentity
+import net.asksakis.massdroidv2.domain.recommendation.normalizeGenre
 import net.asksakis.massdroidv2.domain.repository.AlbumScore
 import net.asksakis.massdroidv2.domain.repository.ArtistScore
 import net.asksakis.massdroidv2.domain.repository.DecadeScore
@@ -99,7 +100,7 @@ class PlayHistoryRepositoryImpl @Inject constructor(
         }
 
         for (genre in track.genres) {
-            val normalized = genre.lowercase().trim()
+            val normalized = normalizeGenre(genre)
             if (normalized.isNotBlank()) {
                 dao.insertGenre(GenreEntity(name = normalized))
                 dao.insertTrackGenre(TrackGenreEntity(trackUri = trackKey, genreName = normalized))
@@ -255,7 +256,7 @@ class PlayHistoryRepositoryImpl @Inject constructor(
 
     override suspend fun getGenreArtistMap(): Map<String, List<String>> {
         return dao.getGenreArtistUris()
-            .groupBy({ it.genre }, { it.artistUri })
+            .groupBy({ normalizeGenre(it.genre) }, { it.artistUri })
     }
 
     override suspend fun getRediscoverAlbums(limit: Int): List<RecentAlbum> {
@@ -301,6 +302,9 @@ class PlayHistoryRepositoryImpl @Inject constructor(
         )
         dao.deleteExpiredArtistTrackCache(now - (14 * MILLIS_PER_DAY))
     }
+
+    override suspend fun searchArtistUrisByGenre(query: String, limit: Int): List<String> =
+        dao.searchArtistUrisByGenre(query, limit)
 
     override suspend fun cleanup(retentionMonths: Int) {
         val cutoff = System.currentTimeMillis() - (retentionMonths * 30L * MILLIS_PER_DAY)

--- a/app/src/main/java/net/asksakis/massdroidv2/data/repository/PlayerRepositoryImpl.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/data/repository/PlayerRepositoryImpl.kt
@@ -9,6 +9,7 @@ import net.asksakis.massdroidv2.data.websocket.*
 import net.asksakis.massdroidv2.domain.model.*
 import net.asksakis.massdroidv2.data.lastfm.LastFmGenreResolver
 import net.asksakis.massdroidv2.domain.recommendation.MediaIdentity
+import net.asksakis.massdroidv2.domain.recommendation.normalizeGenre
 import net.asksakis.massdroidv2.domain.repository.PlayHistoryRepository
 import net.asksakis.massdroidv2.domain.repository.PlayerRepository
 import net.asksakis.massdroidv2.domain.repository.SettingsRepository
@@ -366,22 +367,24 @@ class PlayerRepositoryImpl @Inject constructor(
         track: Track,
         artists: List<Pair<String, String>>
     ): Track {
-        val mergedGenres = LinkedHashSet<String>()
-        mergedGenres.addAll(normalizeGenres(track.genres))
-        artists.forEach { (artistUri, _) ->
-            artistGenreCache[artistUri]?.let { mergedGenres.addAll(normalizeGenres(it)) }
-        }
-        if (mergedGenres.isNotEmpty()) {
-            return track.copy(genres = mergedGenres.toList())
-        }
-
-        // Try Last.fm first (better genre data when API key is configured)
+        // Always try Last.fm first (curated whitelist, more accurate than raw provider tags)
+        val lastFmGenres = LinkedHashSet<String>()
         artists.forEach { (_, name) ->
             val tags = lastFmGenreResolver.resolve(name)
             if (tags.isNotEmpty()) {
                 Log.d(TAG, "History genres from Last.fm '$name': $tags")
-                mergedGenres.addAll(tags)
+                lastFmGenres.addAll(tags)
             }
+        }
+        if (lastFmGenres.isNotEmpty()) {
+            return track.copy(genres = lastFmGenres.toList())
+        }
+
+        // Fall back to MA provider genres + artist cache
+        val mergedGenres = LinkedHashSet<String>()
+        mergedGenres.addAll(normalizeGenres(track.genres))
+        artists.forEach { (artistUri, _) ->
+            artistGenreCache[artistUri]?.let { mergedGenres.addAll(normalizeGenres(it)) }
         }
         if (mergedGenres.isNotEmpty()) {
             return track.copy(genres = mergedGenres.toList())
@@ -519,7 +522,7 @@ class PlayerRepositoryImpl @Inject constructor(
         genres.forEach { raw ->
             val value = raw.trim()
             if (value.isEmpty()) return@forEach
-            val key = value.lowercase()
+            val key = normalizeGenre(value)
             if (seen.add(key)) {
                 result.add(key)
             }

--- a/app/src/main/java/net/asksakis/massdroidv2/data/websocket/MaCommandContracts.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/data/websocket/MaCommandContracts.kt
@@ -65,6 +65,10 @@ object MaCommands {
         fun cmd(command: String): String = "$CMD_PREFIX/$command"
     }
 
+    object Metadata {
+        const val GET_TRACK_LYRICS = "metadata/get_track_lyrics"
+    }
+
     object ConfigPlayers {
         const val GET = "config/players/get"
         const val SAVE = "config/players/save"

--- a/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/DiscoverSectionBuilder.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/DiscoverSectionBuilder.kt
@@ -39,8 +39,8 @@ class DiscoverSectionBuilder @Inject constructor() {
 
         // 1. Genre Radio (BLL-weighted, top 10)
         val sortedGenres = if (bllGenreScores.isNotEmpty()) {
-            val scoreMap = bllGenreScores.associate { it.genre.lowercase() to it.score }
-            genreItems.sortedByDescending { scoreMap[it.name.lowercase()] ?: 0.0 }
+            val scoreMap = bllGenreScores.associate { normalizeGenre(it.genre) to it.score }
+            genreItems.sortedByDescending { scoreMap[normalizeGenre(it.name)] ?: 0.0 }
         } else {
             genreItems
         }.take(10)

--- a/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/MediaIdentity.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/MediaIdentity.kt
@@ -14,7 +14,10 @@ fun Track.canonicalKey(): String? = MediaIdentity.canonicalTrackKey(itemId = ite
 fun List<ArtistScore>.toScoreMap(): Map<String, Double> = associate { it.artistUri to it.score }
 
 @JvmName("genreScoresToMap")
-fun List<GenreScore>.toScoreMap(): Map<String, Double> = associate { it.genre.lowercase() to it.score }
+fun List<GenreScore>.toScoreMap(): Map<String, Double> = associate { normalizeGenre(it.genre) to it.score }
+
+/** Single canonical form for genre names across the app. */
+fun normalizeGenre(genre: String): String = genre.trim().lowercase()
 
 object MediaIdentity {
 

--- a/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/MixEngine.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/MixEngine.kt
@@ -80,7 +80,7 @@ class MixEngine @Inject constructor() {
             is MixMode.SmartMix -> mode.genreScores.toScoreMap()
             is MixMode.GenreMix -> emptyMap()
         }
-        val targetGenre = (mode as? MixMode.GenreMix)?.let { normalizeGenre(it.genre) }
+        val targetGenre = (mode as? MixMode.GenreMix)?.let { fuzzyNormalizeGenre(it.genre) }
 
         val seenTrackKeys = mutableSetOf<String>()
         val byArtistCount = mutableMapOf<String, Int>()
@@ -108,7 +108,7 @@ class MixEngine @Inject constructor() {
                         if (confidence <= 0.0) return@mapNotNull null
                         confidence * 1.25
                     } else {
-                        track.genres.sumOf { g -> genreScoreMap[g.lowercase()] ?: 0.0 } * 0.6
+                        track.genres.sumOf { g -> genreScoreMap[normalizeGenre(g)] ?: 0.0 } * 0.6
                     }
 
                     val trackAlbumKey = MediaIdentity.canonicalAlbumKey(track.albumItemId, track.albumUri)
@@ -194,7 +194,7 @@ class MixEngine @Inject constructor() {
     ): List<String> {
         val random = Random(randomSeed)
         val artistScoreMap = mode.artistScores.toScoreMap()
-        val topGenres = mode.genreScores.take(TOP_GENRES_LIMIT).map { it.genre.lowercase() }
+        val topGenres = mode.genreScores.take(TOP_GENRES_LIMIT).map { normalizeGenre(it.genre) }
         val scoreByUri = mutableMapOf<String, Double>()
         val comfortCandidates = linkedSetOf<String>()
         val genreCandidates = linkedSetOf<String>()
@@ -389,7 +389,7 @@ class MixEngine @Inject constructor() {
     // --- Genre matching (GenreMix) ---
 
     private fun genreConfidence(targetGenre: String, track: Track): Double {
-        val trackGenres = track.genres.map(::normalizeGenre).filter { it.isNotBlank() }
+        val trackGenres = track.genres.map(::fuzzyNormalizeGenre).filter { it.isNotBlank() }
         return when {
             trackGenres.any { genreMatches(targetGenre, it) } -> 1.0
             trackGenres.isEmpty() -> 0.58
@@ -410,12 +410,11 @@ class MixEngine @Inject constructor() {
             .filter { it.isNotBlank() }
             .toSet()
 
-    private fun normalizeGenre(value: String): String =
-        value.lowercase()
+    private fun fuzzyNormalizeGenre(value: String): String =
+        normalizeGenre(value)
             .replace("&", "and")
             .replace("-", " ")
             .replace(Regex("\\s+"), " ")
-            .trim()
 
     // --- Interleaving ---
 

--- a/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/RecommendationEngine.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/domain/recommendation/RecommendationEngine.kt
@@ -44,6 +44,7 @@ class RecommendationEngine @Inject constructor() {
         artistIdentity: (Artist) -> String = { it.uri },
         similarArtistScores: Map<String, Double> = emptyMap(),
         similarArtistUris: Set<String> = emptySet(),
+        enrichedArtistGenres: Map<String, Set<String>> = emptyMap(),
         count: Int = 10
     ): List<Artist> {
         if (genreScores.isEmpty()) return candidates.shuffled().take(count)
@@ -60,10 +61,17 @@ class RecommendationEngine @Inject constructor() {
         val genreScoreMap = genreScores.toScoreMap()
         val topGenreNames = genreScoreMap.keys
 
+        fun resolveGenres(artist: Artist): Set<String> {
+            val maGenres = artist.genres.map { normalizeGenre(it) }.toSet()
+            if (maGenres.isNotEmpty()) return maGenres
+            return enrichedArtistGenres[artistIdentity(artist)].orEmpty()
+        }
+
         // Score each candidate by sum of their genre affinities + signal + similar bonus
         val scored = eligible.map { artist ->
             val key = artistIdentity(artist)
-            val affinityScore = artist.genres.sumOf { g -> genreScoreMap[g.lowercase()] ?: 0.0 }
+            val genres = resolveGenres(artist)
+            val affinityScore = genres.sumOf { g -> genreScoreMap[g] ?: 0.0 }
             val signalBoost = artistSignalScores[key] ?: 0.0
             val similarBonus = (similarArtistScores[key] ?: 0.0) * 0.6
             ScoredArtist(artist, affinityScore + signalBoost * 0.5 + similarBonus)
@@ -74,7 +82,7 @@ class RecommendationEngine @Inject constructor() {
         val wildcardCount = count - exploitCount - exploreCount
 
         // Exploit: MMR re-ranked top scored (with jitter for variety)
-        val exploitPicks = mmrRerank(scored, ARTIST_LAMBDA, exploitCount) { it.artist.genres.map { g -> g.lowercase() }.toSet() }
+        val exploitPicks = mmrRerank(scored, ARTIST_LAMBDA, exploitCount) { resolveGenres(it.artist) }
         val usedUris = exploitPicks.mapTo(mutableSetOf()) { artistIdentity(it.artist) }
 
         // Explore: similar artists first, then adjacent genre artists
@@ -87,9 +95,9 @@ class RecommendationEngine @Inject constructor() {
             genreAdjacency[g].orEmpty()
         } - topGenreNames
         val adjacentCandidates = if (adjacentGenres.isNotEmpty()) {
-            eligible.filter { artistIdentity(it) !in usedUris && it.genres.any { g -> g.lowercase() in adjacentGenres } }
+            eligible.filter { artistIdentity(it) !in usedUris && resolveGenres(it).any { g -> g in adjacentGenres } }
         } else {
-            eligible.filter { artistIdentity(it) !in usedUris && it.genres.none { g -> g.lowercase() in topGenreNames } }
+            eligible.filter { artistIdentity(it) !in usedUris && resolveGenres(it).none { g -> g in topGenreNames } }
         }
         val exploreCandidates = (similarCandidates + adjacentCandidates).distinctBy { artistIdentity(it) }
         val explorePicks = exploreCandidates.shuffled().take(exploreCount)

--- a/app/src/main/java/net/asksakis/massdroidv2/domain/repository/PlayHistoryRepository.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/domain/repository/PlayHistoryRepository.kt
@@ -75,6 +75,7 @@ interface PlayHistoryRepository {
     suspend fun getPlaysForTimeAnalysis(days: Int = 30): List<Long>
     suspend fun getCachedArtistTracks(artistUri: String, maxAgeMs: Long): List<Track>?
     suspend fun cacheArtistTracks(artistUri: String, tracks: List<Track>)
+    suspend fun searchArtistUrisByGenre(query: String, limit: Int = 30): List<String>
     suspend fun cleanup(retentionMonths: Int = 6)
     suspend fun clearRecommendationData()
 }

--- a/app/src/main/java/net/asksakis/massdroidv2/service/PlaybackService.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/service/PlaybackService.kt
@@ -496,10 +496,11 @@ class PlaybackService : MediaLibraryService() {
             // Notification buttons -> normal flow (controls selected player)
             if (session.isMediaNotificationController(controllerInfo)) return false
 
-            // BT/hardware buttons: route to sendspin when active
-            val ctrl = sendspinController ?: return false
-            if (!sendspinActive) return false
-            ctrl.sendspinPlayerId ?: return false
+            // BT/hardware buttons: route to sendspin when active, consume otherwise
+            // (prevent accidental playback on remote players from BT auto-play)
+            val ctrl = sendspinController ?: return true
+            if (!sendspinActive) return true
+            ctrl.sendspinPlayerId ?: return true
 
             val keyEvent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT, KeyEvent::class.java)
@@ -931,11 +932,12 @@ class RemoteControlPlayer(
                         .setAlbumTitle(entry.album.ifEmpty { null })
                         .build()
                 }
+                val durMs = if (index == 0 && _durationMs > 0) _durationMs else entry.durationMs
                 val item = MediaItem.Builder().setMediaMetadata(meta).build()
                 MediaItemData.Builder(entry.id)
                     .setMediaItem(item)
                     .setMediaMetadata(meta)
-                    .setDurationUs(if (entry.durationMs > 0) entry.durationMs * 1000 else C_TIME_UNSET)
+                    .setDurationUs(if (durMs > 0) durMs * 1000 else C_TIME_UNSET)
                     .build()
             })
         } else if (_title.isNotEmpty()) {

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/components/VolumeSlider.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/components/VolumeSlider.kt
@@ -19,24 +19,30 @@ fun VolumeSlider(
     isMuted: Boolean,
     onVolumeChange: (Int) -> Unit,
     onMuteToggle: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    compact: Boolean = false
 ) {
     val haptic = LocalHapticFeedback.current
+    val iconSize = if (compact) 20.dp else 24.dp
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().let { if (compact) it.height(36.dp) else it },
         verticalAlignment = Alignment.CenterVertically
     ) {
-        IconButton(onClick = {
-            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-            onMuteToggle()
-        }) {
+        IconButton(
+            onClick = {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                onMuteToggle()
+            },
+            modifier = if (compact) Modifier.size(32.dp) else Modifier
+        ) {
             Icon(
                 imageVector = when {
                     isMuted || volume == 0 -> Icons.Default.VolumeMute
                     volume < 50 -> Icons.Default.VolumeDown
                     else -> Icons.Default.VolumeUp
                 },
-                contentDescription = "Volume"
+                contentDescription = "Volume",
+                modifier = Modifier.size(iconSize)
             )
         }
 
@@ -50,13 +56,13 @@ fun VolumeSlider(
                 onVolumeChange(sliderValue.toInt())
             },
             valueRange = 0f..100f,
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f).let { if (compact) it.height(28.dp) else it }
         )
 
         Text(
             text = "${sliderValue.toInt()}%",
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.width(40.dp)
+            style = if (compact) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodySmall,
+            modifier = Modifier.width(if (compact) 32.dp else 40.dp)
         )
     }
 }

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/DiscoverContentLoader.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/DiscoverContentLoader.kt
@@ -8,6 +8,7 @@ import net.asksakis.massdroidv2.domain.model.Artist
 import net.asksakis.massdroidv2.domain.model.RecommendationFolder
 import net.asksakis.massdroidv2.domain.model.RecommendationItems
 import net.asksakis.massdroidv2.domain.recommendation.MediaIdentity
+import net.asksakis.massdroidv2.domain.recommendation.normalizeGenre
 import net.asksakis.massdroidv2.domain.recommendation.canonicalKey
 import net.asksakis.massdroidv2.domain.repository.MusicRepository
 import net.asksakis.massdroidv2.domain.repository.PlayHistoryRepository
@@ -158,10 +159,16 @@ class DiscoverContentLoader(
         historyGenreArtists: Map<String, List<String>>,
         artistByUri: Map<String, Artist>
     ): Triple<List<GenreItem>, Map<String, List<String>>, Map<String, List<String>>> {
+        // Artists with enriched genres in play history (Last.fm preferred)
+        val enrichedArtistKeys = buildSet {
+            historyGenreArtists.values.forEach { addAll(it) }
+        }
         val genreMap = mutableMapOf<String, MutableList<Artist>>()
         for (artist in artists) {
+            val key = artist.canonicalKey()
+            if (key != null && key in enrichedArtistKeys) continue
             for (genre in artist.genres) {
-                genreMap.getOrPut(genre.lowercase()) { mutableListOf() }.add(artist)
+                genreMap.getOrPut(normalizeGenre(genre)) { mutableListOf() }.add(artist)
             }
         }
 

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/DiscoverRecommendationOrchestrator.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/DiscoverRecommendationOrchestrator.kt
@@ -7,6 +7,7 @@ import net.asksakis.massdroidv2.data.lastfm.LastFmSimilarResolver
 import net.asksakis.massdroidv2.domain.model.Album
 import net.asksakis.massdroidv2.domain.model.Artist
 import net.asksakis.massdroidv2.domain.recommendation.MediaIdentity
+import net.asksakis.massdroidv2.domain.recommendation.normalizeGenre
 import net.asksakis.massdroidv2.domain.recommendation.RecommendationEngine
 import net.asksakis.massdroidv2.domain.recommendation.toScoreMap
 import net.asksakis.massdroidv2.domain.recommendation.ScoredAlbum
@@ -31,10 +32,12 @@ class DiscoverRecommendationOrchestrator(
         val genreScores = playHistoryRepository.getScoredGenres(days = 90, limit = 20)
         val artistScores = playHistoryRepository.getScoredArtists(days = 90, limit = 50)
         val genreAdjacency = playHistoryRepository.getGenreAdjacencyMap()
+        val enrichedArtistGenres = invertGenreArtistMap()
 
         Log.d(
             ORCHESTRATOR_TAG,
-            "BLL: ${genreScores.size} genres, ${artistScores.size} artists, ${genreAdjacency.size} adjacency"
+            "BLL: ${genreScores.size} genres, ${artistScores.size} artists, " +
+                "${genreAdjacency.size} adjacency, ${enrichedArtistGenres.size} enriched"
         )
         if (genreScores.isNotEmpty()) {
             Log.d(
@@ -71,6 +74,7 @@ class DiscoverRecommendationOrchestrator(
             artistIdentity = artistIdentity,
             similarArtistScores = similarArtistScores,
             similarArtistUris = similarArtistUris,
+            enrichedArtistGenres = enrichedArtistGenres,
             count = 10
         )
     }
@@ -101,8 +105,12 @@ class DiscoverRecommendationOrchestrator(
                 .filterNot { it in excludedArtistUris }
                 .toSet()
 
+            val enrichedArtistGenres = invertGenreArtistMap()
             val artistGenreMap = candidateArtists.mapNotNull { artist ->
-                artistIdentity(artist).let { it to artist.genres.map { g -> g.lowercase() }.toSet() }
+                val key = artistIdentity(artist)
+                val genres = artist.genres.map { g -> normalizeGenre(g) }.toSet()
+                    .ifEmpty { enrichedArtistGenres[key].orEmpty() }
+                key to genres
             }.toMap()
             val genreScoreMap = genreScores.toScoreMap()
 
@@ -137,11 +145,14 @@ class DiscoverRecommendationOrchestrator(
                     allCandidateAlbums.addAll(def.await())
                 }
 
-                val topGenreNames = genreScores.map { it.genre.lowercase() }.toSet()
+                val topGenreNames = genreScores.map { normalizeGenre(it.genre) }.toSet()
                 val discoveryArtists = candidateArtists
                     .filter { artist -> artistIdentity(artist) !in topArtistUris }
                     .filterNot { artist -> artistIdentity(artist) in excludedArtistUris }
-                    .filter { it.genres.any { g -> g.lowercase() in topGenreNames } }
+                    .filter { artist ->
+                        val genres = artistGenreMap[artistIdentity(artist)].orEmpty()
+                        genres.any { it in topGenreNames }
+                    }
                     .shuffled()
                     .take(5)
 
@@ -149,7 +160,7 @@ class DiscoverRecommendationOrchestrator(
                     async {
                         try {
                             val albums = musicRepository.getArtistAlbums(artist.itemId, artist.provider)
-                            val genres = artist.genres.map { g -> g.lowercase() }.toSet()
+                            val genres = artistGenreMap[artistIdentity(artist)].orEmpty()
                             albums.filter { album ->
                                 val key = albumIdentity(album)
                                 key !in recentAlbumUris && album.albumType != "single"
@@ -250,5 +261,16 @@ class DiscoverRecommendationOrchestrator(
 
         Log.d(ORCHESTRATOR_TAG, "Similar artists: ${similarUris.size} matched from ${topArtists.size} sources")
         similarScores to similarUris
+    }
+
+    private suspend fun invertGenreArtistMap(): Map<String, Set<String>> {
+        val genreArtistMap = playHistoryRepository.getGenreArtistMap()
+        val result = mutableMapOf<String, MutableSet<String>>()
+        for ((genre, uris) in genreArtistMap) {
+            for (uri in uris) {
+                result.getOrPut(uri) { mutableSetOf() }.add(genre)
+            }
+        }
+        return result
     }
 }

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/DiscoverViewModel.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/DiscoverViewModel.kt
@@ -38,6 +38,7 @@ import net.asksakis.massdroidv2.domain.model.RecommendationItems
 import net.asksakis.massdroidv2.domain.model.Track
 import net.asksakis.massdroidv2.domain.recommendation.DiscoverSection
 import net.asksakis.massdroidv2.domain.recommendation.DiscoverSectionBuilder
+import net.asksakis.massdroidv2.domain.recommendation.normalizeGenre
 import net.asksakis.massdroidv2.domain.recommendation.MediaIdentity
 import net.asksakis.massdroidv2.domain.recommendation.MixEngine
 import net.asksakis.massdroidv2.domain.recommendation.canonicalKey
@@ -121,7 +122,8 @@ class DiscoverViewModel @Inject constructor(
     private val recommendationEngine: RecommendationEngine,
     private val mixEngine: MixEngine,
     private val sectionBuilder: DiscoverSectionBuilder,
-    private val lastFmSimilarResolver: net.asksakis.massdroidv2.data.lastfm.LastFmSimilarResolver
+    private val lastFmSimilarResolver: net.asksakis.massdroidv2.data.lastfm.LastFmSimilarResolver,
+    private val lastFmLibraryEnricher: net.asksakis.massdroidv2.data.lastfm.LastFmLibraryEnricher
 ) : ViewModel() {
 
     private val sectionCoordinator = DiscoverSectionCoordinator(
@@ -544,10 +546,10 @@ class DiscoverViewModel @Inject constructor(
         if (recent.isEmpty()) return longTerm
         val merged = mutableMapOf<String, Double>()
         for (score in longTerm) {
-            merged[score.genre.lowercase()] = (merged[score.genre.lowercase()] ?: 0.0) + score.score
+            merged[normalizeGenre(score.genre)] = (merged[normalizeGenre(score.genre)] ?: 0.0) + score.score
         }
         for (score in recent) {
-            val genre = score.genre.lowercase()
+            val genre = normalizeGenre(score.genre)
             merged[genre] = (merged[genre] ?: 0.0) + score.score * 0.9
         }
         return merged.entries
@@ -579,6 +581,7 @@ class DiscoverViewModel @Inject constructor(
                 artistByUri = merged.mapNotNull { artist ->
                     artist.canonicalKey()?.let { it to artist }
                 }.toMap()
+                lastFmLibraryEnricher.enrichInBackground(merged)
 
                 val smartListeningEnabled = settingsRepository.smartListeningEnabled.first()
                 if (smartListeningEnabled) {

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/home/HomeScreen.kt
@@ -91,6 +91,7 @@ import net.asksakis.massdroidv2.domain.model.Artist
 import net.asksakis.massdroidv2.domain.model.Playlist
 import net.asksakis.massdroidv2.domain.model.Track
 import net.asksakis.massdroidv2.domain.recommendation.DiscoverSection
+import net.asksakis.massdroidv2.domain.recommendation.normalizeGenre
 import net.asksakis.massdroidv2.ui.components.formatAlbumTypeYear
 import net.asksakis.massdroidv2.ui.components.EqualizerBars
 
@@ -1036,5 +1037,5 @@ private fun genrePalette(name: String): Triple<Color, Color, Color> {
         Triple(Color(0xFF2B2B46), Color(0xFF11111C), Color(0x556C8CFF)),
         Triple(Color(0xFF3A2531), Color(0xFF160E12), Color(0x55FF6FAE))
     )
-    return palettes[(name.lowercase().hashCode().absoluteValue) % palettes.size]
+    return palettes[(normalizeGenre(name).hashCode().absoluteValue) % palettes.size]
 }

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/AlbumDetailScreen.kt
@@ -104,7 +104,7 @@ fun AlbumDetailScreen(
                         contentDescription = "Album art",
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 24.dp)
+                            .padding(horizontal = 48.dp)
                             .aspectRatio(1f)
                             .clip(MaterialTheme.shapes.medium),
                         contentScale = ContentScale.Crop

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/ArtistDetailScreen.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/ArtistDetailScreen.kt
@@ -144,6 +144,7 @@ fun ArtistDetailScreen(
                             contentDescription = "Artist image",
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .padding(horizontal = 24.dp)
                                 .aspectRatio(16f / 9f)
                                 .clip(MaterialTheme.shapes.medium),
                             contentScale = ContentScale.Crop

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/LibraryScreen.kt
@@ -479,7 +479,7 @@ private fun <T> MediaList(
             InfiniteGridHandler(gridState, items.size, threshold = 6, onLoadMore = onLoadMore)
             LazyVerticalGrid(
                 state = gridState,
-                columns = GridCells.Adaptive(minSize = 150.dp),
+                columns = GridCells.Adaptive(minSize = 120.dp),
                 contentPadding = PaddingValues(8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/LibraryViewModel.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/LibraryViewModel.kt
@@ -6,20 +6,26 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import net.asksakis.massdroidv2.data.websocket.ConnectionState
 import net.asksakis.massdroidv2.data.websocket.EventType
 import net.asksakis.massdroidv2.data.websocket.MaWebSocketClient
 import net.asksakis.massdroidv2.domain.model.*
 import net.asksakis.massdroidv2.domain.recommendation.MediaIdentity
+import net.asksakis.massdroidv2.domain.recommendation.normalizeGenre
 import net.asksakis.massdroidv2.data.database.PlayHistoryDao
 import net.asksakis.massdroidv2.data.lastfm.LastFmAlbumInfoResolver
 import net.asksakis.massdroidv2.data.lastfm.LastFmArtistInfoResolver
 import net.asksakis.massdroidv2.data.lastfm.LastFmGenreResolver
+import net.asksakis.massdroidv2.data.lastfm.LastFmLibraryEnricher
 import net.asksakis.massdroidv2.data.lastfm.LastFmSimilarResolver
 import net.asksakis.massdroidv2.domain.repository.MusicRepository
+import net.asksakis.massdroidv2.domain.repository.PlayHistoryRepository
 import net.asksakis.massdroidv2.domain.repository.PlayerRepository
 import net.asksakis.massdroidv2.domain.repository.SettingsRepository
 import net.asksakis.massdroidv2.domain.repository.SmartListeningRepository
@@ -34,7 +40,9 @@ class LibraryViewModel @Inject constructor(
     private val playerRepository: PlayerRepository,
     private val wsClient: MaWebSocketClient,
     private val settingsRepository: SettingsRepository,
-    private val smartListeningRepository: SmartListeningRepository
+    private val smartListeningRepository: SmartListeningRepository,
+    private val playHistoryRepository: PlayHistoryRepository,
+    private val lastFmLibraryEnricher: LastFmLibraryEnricher
 ) : ViewModel() {
 
     private val _artists = MutableStateFlow<List<Artist>>(emptyList())
@@ -247,15 +255,46 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
+    private fun parseMediaUri(uri: String): Pair<String, String>? {
+        val sep = uri.indexOf("://")
+        if (sep < 0) return null
+        val provider = uri.substring(0, sep)
+        val itemId = uri.substringAfterLast("/")
+        return if (provider.isNotBlank() && itemId.isNotBlank()) provider to itemId else null
+    }
+
     fun loadArtists() {
         viewModelScope.launch {
             _isLoading.value = true
             try {
-                val items = musicRepository.getArtists(
-                    search = currentSearch, limit = PAGE_SIZE, offset = 0, orderBy = currentOrderBy, favoriteOnly = currentFavoriteOnly
-                )
-                _artists.value = items
-                hasMoreArtists = items.size >= PAGE_SIZE
+                val query = currentSearch
+                val apiDeferred = async {
+                    musicRepository.getArtists(
+                        search = query, limit = PAGE_SIZE, offset = 0, orderBy = currentOrderBy, favoriteOnly = currentFavoriteOnly
+                    )
+                }
+                val genreDeferred = if (query != null && query.length >= 3) {
+                    async { runCatching { playHistoryRepository.searchArtistUrisByGenre(query) }.getOrElse { emptyList() } }
+                } else null
+
+                val apiResults = apiDeferred.await()
+                val genreUris = genreDeferred?.await().orEmpty()
+
+                val merged = if (genreUris.isNotEmpty()) {
+                    val existingUris = apiResults.map { it.uri }.toSet()
+                    val newUris = genreUris.filter { it !in existingUris }.take(20)
+                    val genreArtists = if (newUris.isNotEmpty()) {
+                        supervisorScope {
+                            newUris.map { uri -> async { runCatching { parseMediaUri(uri)?.let { (prov, id) -> musicRepository.getArtist(id, prov) } }.getOrNull() } }.awaitAll().filterNotNull()
+                        }
+                    } else emptyList()
+                    val seenUris = existingUris.toMutableSet()
+                    apiResults + genreArtists.filter { seenUris.add(it.uri) }
+                } else apiResults
+
+                _artists.value = merged
+                hasMoreArtists = apiResults.size >= PAGE_SIZE
+                lastFmLibraryEnricher.enrichInBackground(apiResults)
             } catch (_: Exception) {}
             _isLoading.value = false
         }
@@ -271,6 +310,7 @@ class LibraryViewModel @Inject constructor(
                 )
                 _artists.value = _artists.value + items
                 hasMoreArtists = items.size >= PAGE_SIZE
+                lastFmLibraryEnricher.enrichInBackground(items)
             } catch (_: Exception) {
             } finally {
                 _isLoadingMore.value = false
@@ -282,11 +322,35 @@ class LibraryViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
             try {
-                val items = musicRepository.getAlbums(
-                    search = currentSearch, limit = PAGE_SIZE, offset = 0, orderBy = currentOrderBy, favoriteOnly = currentFavoriteOnly
-                )
-                _albums.value = items
-                hasMoreAlbums = items.size >= PAGE_SIZE
+                val query = currentSearch
+                val apiDeferred = async {
+                    musicRepository.getAlbums(
+                        search = query, limit = PAGE_SIZE, offset = 0, orderBy = currentOrderBy, favoriteOnly = currentFavoriteOnly
+                    )
+                }
+                val genreDeferred = if (query != null && query.length >= 3) {
+                    async { runCatching { playHistoryRepository.searchArtistUrisByGenre(query) }.getOrElse { emptyList() } }
+                } else null
+
+                val apiResults = apiDeferred.await()
+                val genreUris = genreDeferred?.await().orEmpty()
+
+                val merged = if (genreUris.isNotEmpty()) {
+                    val genreAlbums: List<Album> = supervisorScope {
+                        genreUris.take(10).map { uri ->
+                            async {
+                                runCatching {
+                                    parseMediaUri(uri)?.let { (prov, id) -> musicRepository.getArtistAlbums(id, prov) }
+                                }.getOrNull().orEmpty()
+                            }
+                        }.awaitAll().flatten()
+                    }
+                    val seenUris = apiResults.map { it.uri }.toMutableSet()
+                    apiResults + genreAlbums.filter { seenUris.add(it.uri) }
+                } else apiResults
+
+                _albums.value = merged
+                hasMoreAlbums = apiResults.size >= PAGE_SIZE
             } catch (_: Exception) {}
             _isLoading.value = false
         }
@@ -313,11 +377,35 @@ class LibraryViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
             try {
-                val items = musicRepository.getTracks(
-                    search = currentSearch, limit = PAGE_SIZE, offset = 0, orderBy = currentOrderBy, favoriteOnly = currentFavoriteOnly
-                )
-                _tracks.value = items
-                hasMoreTracks = items.size >= PAGE_SIZE
+                val query = currentSearch
+                val apiDeferred = async {
+                    musicRepository.getTracks(
+                        search = query, limit = PAGE_SIZE, offset = 0, orderBy = currentOrderBy, favoriteOnly = currentFavoriteOnly
+                    )
+                }
+                val genreDeferred = if (query != null && query.length >= 3) {
+                    async { runCatching { playHistoryRepository.searchArtistUrisByGenre(query) }.getOrElse { emptyList() } }
+                } else null
+
+                val apiResults = apiDeferred.await()
+                val genreUris = genreDeferred?.await().orEmpty()
+
+                val merged = if (genreUris.isNotEmpty()) {
+                    val genreTracks: List<Track> = supervisorScope {
+                        genreUris.take(10).map { uri ->
+                            async {
+                                runCatching {
+                                    parseMediaUri(uri)?.let { (prov, id) -> musicRepository.getArtistTracks(id, prov) }
+                                }.getOrNull().orEmpty()
+                            }
+                        }.awaitAll().flatten()
+                    }
+                    val seenUris = apiResults.map { it.uri }.toMutableSet()
+                    apiResults + genreTracks.filter { seenUris.add(it.uri) }
+                } else apiResults
+
+                _tracks.value = merged
+                hasMoreTracks = apiResults.size >= PAGE_SIZE
             } catch (_: Exception) {}
             _isLoading.value = false
         }
@@ -607,7 +695,7 @@ class ArtistDetailViewModel @Inject constructor(
                 } else {
                     candidates.firstNotNullOfOrNull { c ->
                         val detail = musicRepository.getArtist(c.itemId, c.provider)
-                        val cGenres = detail?.genres?.map { it.lowercase() }?.toSet().orEmpty()
+                        val cGenres = detail?.genres?.map { normalizeGenre(it) }?.toSet().orEmpty()
                         when {
                             detail == null -> null
                             cGenres.isEmpty() -> detail

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/nowplaying/NowPlayingScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.automirrored.filled.Subject
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -51,6 +54,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import net.asksakis.massdroidv2.data.lyrics.LyricsProvider
 import net.asksakis.massdroidv2.domain.model.PlaybackState
 import net.asksakis.massdroidv2.domain.model.Playlist
 import net.asksakis.massdroidv2.domain.model.AudioFormatInfo
@@ -87,6 +91,9 @@ fun NowPlayingScreen(
     val artistBlocked = currentArtistUri?.let { it in blockedArtistUris } ?: false
     val canToggleArtistBlock = currentArtistUri != null
     var showPlayerMenu by remember { mutableStateOf(false) }
+    var showLyricsSheet by remember { mutableStateOf(false) }
+    val lyrics by viewModel.lyrics.collectAsStateWithLifecycle()
+    val isLoadingLyrics by viewModel.isLoadingLyrics.collectAsStateWithLifecycle()
     val title = currentTrack?.name ?: player?.currentMedia?.title ?: "No track"
     val artist = currentTrack?.artistNames ?: player?.currentMedia?.artist ?: ""
     val album = currentTrack?.albumName ?: player?.currentMedia?.album ?: ""
@@ -132,10 +139,6 @@ fun NowPlayingScreen(
                         }
                     },
                     actions = {
-                        IconButton(onClick = onNavigateToQueue) {
-                            @Suppress("DEPRECATION")
-                            Icon(Icons.Default.QueueMusic, contentDescription = "Queue")
-                        }
                         IconButton(onClick = { showPlayerMenu = true }) {
                             Icon(Icons.Default.MoreVert, contentDescription = "Player options")
                         }
@@ -168,14 +171,17 @@ fun NowPlayingScreen(
                     duration = duration,
                     player = player,
                     viewModel = viewModel,
-                    artistBlocked = artistBlocked,
-                    canToggleArtistBlock = canToggleArtistBlock,
                     onBack = onBack,
                     onNavigateToQueue = onNavigateToQueue,
                     onShowPlaylistDialog = {
                         showPlaylistDialog = true
                         viewModel.loadPlaylists(force = true)
                     },
+                    onShowLyrics = {
+                        showLyricsSheet = true
+                        viewModel.loadLyrics()
+                    },
+                    onShowPlayerMenu = { showPlayerMenu = true },
                     onNavigateToArtist = onNavigateToArtist,
                     onNavigateToAlbum = onNavigateToAlbum
                 )
@@ -198,6 +204,11 @@ fun NowPlayingScreen(
                         showPlaylistDialog = true
                         viewModel.loadPlaylists(force = true)
                     },
+                    onShowLyrics = {
+                        showLyricsSheet = true
+                        viewModel.loadLyrics()
+                    },
+                    onNavigateToQueue = onNavigateToQueue,
                     onNavigateToArtist = onNavigateToArtist,
                     onNavigateToAlbum = onNavigateToAlbum
                 )
@@ -245,6 +256,15 @@ fun NowPlayingScreen(
             )
         }
     }
+
+    if (showLyricsSheet) {
+        LyricsSheet(
+            lyrics = lyrics,
+            isLoading = isLoadingLyrics,
+            elapsedTime = elapsedTime,
+            onDismiss = { showLyricsSheet = false }
+        )
+    }
 }
 
 @Composable
@@ -263,6 +283,8 @@ private fun NowPlayingPortrait(
     player: net.asksakis.massdroidv2.domain.model.Player?,
     viewModel: NowPlayingViewModel,
     onShowPlaylistDialog: () -> Unit,
+    onShowLyrics: () -> Unit,
+    onNavigateToQueue: () -> Unit,
     onNavigateToArtist: (String, String, String) -> Unit,
     onNavigateToAlbum: (String, String, String) -> Unit
 ) {
@@ -289,7 +311,9 @@ private fun NowPlayingPortrait(
             audioFormat = audioFormat,
             currentTrack = currentTrack,
             viewModel = viewModel,
-            onShowPlaylistDialog = onShowPlaylistDialog
+            onShowPlaylistDialog = onShowPlaylistDialog,
+            onShowLyrics = onShowLyrics,
+            onNavigateToQueue = onNavigateToQueue
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -308,7 +332,8 @@ private fun NowPlayingPortrait(
         SeekBar(
             elapsed = elapsedTime,
             duration = duration,
-            onSeek = { viewModel.seek(it) }
+            onSeek = { viewModel.seek(it) },
+            compact = true
         )
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -326,7 +351,8 @@ private fun NowPlayingPortrait(
             volume = player?.volumeLevel ?: 0,
             isMuted = player?.volumeMuted ?: false,
             onVolumeChange = { viewModel.setVolume(it) },
-            onMuteToggle = { viewModel.toggleMute() }
+            onMuteToggle = { viewModel.toggleMute() },
+            compact = true
         )
     }
 }
@@ -346,16 +372,15 @@ private fun NowPlayingLandscape(
     duration: Double,
     player: net.asksakis.massdroidv2.domain.model.Player?,
     viewModel: NowPlayingViewModel,
-    artistBlocked: Boolean,
-    canToggleArtistBlock: Boolean,
     onBack: () -> Unit,
     onNavigateToQueue: () -> Unit,
     onShowPlaylistDialog: () -> Unit,
+    onShowLyrics: () -> Unit,
+    onShowPlayerMenu: () -> Unit,
     onNavigateToArtist: (String, String, String) -> Unit,
     onNavigateToAlbum: (String, String, String) -> Unit
 ) {
     val haptic = LocalHapticFeedback.current
-    var showPlayerMenu by remember { mutableStateOf(false) }
     Row(
         modifier = Modifier
             .fillMaxSize()
@@ -387,7 +412,7 @@ private fun NowPlayingLandscape(
                 .fillMaxHeight()
                 .padding(start = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.SpaceEvenly
         ) {
             // Back + queue row
             Row(
@@ -408,28 +433,20 @@ private fun NowPlayingLandscape(
                         .align(Alignment.CenterVertically),
                     textAlign = TextAlign.Center
                 )
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = onNavigateToQueue, modifier = Modifier.size(36.dp)) {
-                        @Suppress("DEPRECATION")
-                        Icon(Icons.Default.QueueMusic, contentDescription = "Queue", modifier = Modifier.size(20.dp))
-                    }
-                    IconButton(onClick = { showPlayerMenu = true }, modifier = Modifier.size(36.dp)) {
-                        Icon(Icons.Default.MoreVert, contentDescription = "Player options", modifier = Modifier.size(20.dp))
-                    }
+                IconButton(onClick = onShowPlayerMenu, modifier = Modifier.size(36.dp)) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "Player options", modifier = Modifier.size(20.dp))
                 }
             }
-
-            Spacer(modifier = Modifier.height(8.dp))
 
             QualityActionRow(
                 audioFormat = audioFormat,
                 currentTrack = currentTrack,
                 viewModel = viewModel,
                 onShowPlaylistDialog = onShowPlaylistDialog,
+                onShowLyrics = onShowLyrics,
+                onNavigateToQueue = onNavigateToQueue,
                 compact = true
             )
-
-            Spacer(modifier = Modifier.height(8.dp))
 
             TrackInfoSection(
                 title = title,
@@ -441,15 +458,12 @@ private fun NowPlayingLandscape(
                 compact = true
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
-
             SeekBar(
                 elapsed = elapsedTime,
                 duration = duration,
-                onSeek = { viewModel.seek(it) }
+                onSeek = { viewModel.seek(it) },
+                compact = true
             )
-
-            Spacer(modifier = Modifier.height(4.dp))
 
             TransportControls(
                 isPlaying = isPlaying,
@@ -459,13 +473,12 @@ private fun NowPlayingLandscape(
                 onHaptic = { haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove) }
             )
 
-            Spacer(modifier = Modifier.height(4.dp))
-
             VolumeSlider(
                 volume = player?.volumeLevel ?: 0,
                 isMuted = player?.volumeMuted ?: false,
                 onVolumeChange = { viewModel.setVolume(it) },
-                onMuteToggle = { viewModel.toggleMute() }
+                onMuteToggle = { viewModel.toggleMute() },
+                compact = true
             )
         }
     }
@@ -506,6 +519,8 @@ private fun QualityActionRow(
     currentTrack: net.asksakis.massdroidv2.domain.model.Track?,
     viewModel: NowPlayingViewModel,
     onShowPlaylistDialog: () -> Unit,
+    onShowLyrics: () -> Unit,
+    onNavigateToQueue: () -> Unit,
     compact: Boolean = false
 ) {
     val haptic = LocalHapticFeedback.current
@@ -521,36 +536,200 @@ private fun QualityActionRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            IconButton(
-                onClick = {
-                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                    onShowPlaylistDialog()
-                },
-                modifier = Modifier.size(actionButtonSize)
-            ) {
-                Icon(
-                    Icons.Default.Add,
-                    contentDescription = "Add to playlist",
-                    modifier = Modifier.size(actionIconSize),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onShowPlaylistDialog()
+                    },
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
+                    Icon(
+                        Icons.Default.Add,
+                        contentDescription = "Add to playlist",
+                        modifier = Modifier.size(actionIconSize),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                IconButton(
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onShowLyrics()
+                    },
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.Subject,
+                        contentDescription = "Lyrics",
+                        modifier = Modifier.size(actionIconSize),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
             AudioQualityBadges(audioFormat = audioFormat, compact = compact)
-            IconButton(
-                onClick = {
-                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                    viewModel.toggleFavorite()
-                },
-                modifier = Modifier.size(actionButtonSize)
-            ) {
-                Icon(
-                    if (currentTrack?.favorite == true) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                    contentDescription = "Toggle favorite",
-                    modifier = Modifier.size(actionIconSize),
-                    tint = if (currentTrack?.favorite == true) MaterialTheme.colorScheme.error
-                    else MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                @Suppress("DEPRECATION")
+                IconButton(
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onNavigateToQueue()
+                    },
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
+                    Icon(
+                        Icons.Default.QueueMusic,
+                        contentDescription = "Queue",
+                        modifier = Modifier.size(actionIconSize),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                IconButton(
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        viewModel.toggleFavorite()
+                    },
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
+                    Icon(
+                        if (currentTrack?.favorite == true) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription = "Toggle favorite",
+                        modifier = Modifier.size(actionIconSize),
+                        tint = if (currentTrack?.favorite == true) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LyricsSheet(
+    lyrics: LyricsProvider.LyricsResult?,
+    isLoading: Boolean,
+    elapsedTime: Double,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = SheetDefaults.containerColor()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.85f)
+        ) {
+            SheetDefaults.HeaderTitle(
+                text = "Lyrics",
+                modifier = Modifier.padding(
+                    horizontal = SheetDefaults.HeaderHorizontalPadding,
+                    vertical = SheetDefaults.HeaderVerticalPadding
+                )
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            when {
+                isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                lyrics == null || (lyrics.plainText == null && lyrics.syncedLrc == null) -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "No lyrics available",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                lyrics.syncedLrc != null -> {
+                    SyncedLyricsContent(
+                        lrc = lyrics.syncedLrc,
+                        elapsedTimeMs = (elapsedTime * 1000).toLong()
+                    )
+                }
+                else -> {
+                    PlainLyricsContent(text = lyrics.plainText!!)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlainLyricsContent(text: String) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        contentPadding = PaddingValues(bottom = 32.dp)
+    ) {
+        item {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.4
+            )
+        }
+    }
+}
+
+@Composable
+private fun SyncedLyricsContent(lrc: String, elapsedTimeMs: Long) {
+    val lines = remember(lrc) { LyricsProvider.parseLrc(lrc) }
+    val listState = rememberLazyListState()
+
+    val currentIndex = remember(elapsedTimeMs, lines) {
+        val idx = lines.indexOfLast { it.timeMs <= elapsedTimeMs }
+        if (idx < 0) 0 else idx
+    }
+
+    LaunchedEffect(currentIndex) {
+        if (lines.isNotEmpty() && currentIndex >= 0) {
+            listState.animateScrollToItem(
+                index = currentIndex,
+                scrollOffset = -200
+            )
+        }
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        contentPadding = PaddingValues(top = 8.dp, bottom = 200.dp)
+    ) {
+        itemsIndexed(lines) { index, line ->
+            val isCurrent = index == currentIndex
+            Text(
+                text = line.text.ifBlank { " " },
+                style = if (isCurrent) {
+                    MaterialTheme.typography.titleLarge
+                } else {
+                    MaterialTheme.typography.bodyLarge
+                },
+                color = if (isCurrent) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 6.dp)
+            )
         }
     }
 }
@@ -583,8 +762,10 @@ private fun PlayerOptionsSheet(
     onPlayerSettings: () -> Unit,
     onClick: () -> Unit
 ) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetState = sheetState,
         containerColor = SheetDefaults.containerColor()
     ) {
         Column(modifier = Modifier.padding(bottom = 24.dp)) {
@@ -1143,7 +1324,8 @@ private fun extractColor(bitmap: Bitmap, isDark: Boolean): Color {
 private fun SeekBar(
     elapsed: Double,
     duration: Double,
-    onSeek: (Double) -> Unit
+    onSeek: (Double) -> Unit,
+    compact: Boolean = false
 ) {
     val haptic = LocalHapticFeedback.current
     var seeking by remember { mutableStateOf(false) }
@@ -1176,15 +1358,17 @@ private fun SeekBar(
                 seekTarget = seekValue
                 seeking = false
             },
-            valueRange = 0f..duration.toFloat().coerceAtLeast(1f)
+            valueRange = 0f..duration.toFloat().coerceAtLeast(1f),
+            modifier = if (compact) Modifier.height(28.dp) else Modifier
         )
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(formatTime(displayValue.toDouble()), style = MaterialTheme.typography.bodySmall)
-            Text(formatTime(duration), style = MaterialTheme.typography.bodySmall)
+            val timeStyle = if (compact) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodySmall
+            Text(formatTime(displayValue.toDouble()), style = timeStyle)
+            Text(formatTime(duration), style = timeStyle)
         }
     }
 }

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/nowplaying/NowPlayingViewModel.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/nowplaying/NowPlayingViewModel.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import net.asksakis.massdroidv2.data.lyrics.LyricsProvider
 import net.asksakis.massdroidv2.domain.model.MediaType
 import net.asksakis.massdroidv2.domain.model.Playlist
 import net.asksakis.massdroidv2.domain.model.PlayerConfig
@@ -31,7 +34,8 @@ class NowPlayingViewModel @Inject constructor(
     private val playerRepository: PlayerRepository,
     private val musicRepository: MusicRepository,
     private val smartListeningRepository: SmartListeningRepository,
-    private val wsClient: MaWebSocketClient
+    private val wsClient: MaWebSocketClient,
+    private val lyricsProvider: LyricsProvider
 ) : ViewModel() {
 
     val selectedPlayer = playerRepository.selectedPlayer
@@ -46,12 +50,26 @@ class NowPlayingViewModel @Inject constructor(
     private val _addingToPlaylistId = MutableStateFlow<String?>(null)
     val addingToPlaylistId: StateFlow<String?> = _addingToPlaylistId.asStateFlow()
 
+    private val _lyrics = MutableStateFlow<LyricsProvider.LyricsResult?>(null)
+    val lyrics: StateFlow<LyricsProvider.LyricsResult?> = _lyrics.asStateFlow()
+    private val _isLoadingLyrics = MutableStateFlow(false)
+    val isLoadingLyrics: StateFlow<Boolean> = _isLoadingLyrics.asStateFlow()
+
     private val _error = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val error: SharedFlow<String> = _error.asSharedFlow()
 
     init {
         viewModelScope.launch {
             smartListeningRepository.blockedArtistUris.collect { _blockedArtistUris.value = it }
+        }
+        viewModelScope.launch {
+            queueState
+                .map { it?.currentItem?.track?.uri }
+                .distinctUntilChanged()
+                .collect {
+                    _lyrics.value = null
+                    lyricsProvider.clearCache()
+                }
         }
         viewModelScope.launch {
             wsClient.events.collect { event ->
@@ -223,6 +241,22 @@ class NowPlayingViewModel @Inject constructor(
                 _error.tryEmit("Failed to load playlists")
             } finally {
                 _isLoadingPlaylists.value = false
+            }
+        }
+    }
+
+    fun loadLyrics() {
+        val track = queueState.value?.currentItem?.track ?: return
+        if (_isLoadingLyrics.value) return
+        viewModelScope.launch {
+            _isLoadingLyrics.value = true
+            try {
+                _lyrics.value = lyricsProvider.getLyrics(track.itemId, track.provider, track.uri)
+            } catch (e: Exception) {
+                Log.w(TAG, "loadLyrics failed: ${e.message}")
+                _lyrics.value = LyricsProvider.LyricsResult(null, null)
+            } finally {
+                _isLoadingLyrics.value = false
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Genre-based library search**: hybrid search that queries Room `artist_genres` table in parallel with MA API name search. Finds artists/albums/tracks by genre (e.g. searching "ambient" shows ambient artists). Activates for queries >= 3 characters, gracefully degrades without Last.fm API key.
- **Library enrichment**: `LastFmLibraryEnricher` now runs during Library browsing (not just Discover), progressively building the genre database as users scroll. Queue-based processing ensures no artist batches are dropped.
- **Enriched recommendations**: "Artists You May Like" and "Albums You May Like" now use Last.fm enriched genres as fallback when the music provider has no genre data (e.g. Deezer). Previously these artists scored 0 and were filtered out.
- **Lyrics support**: new `LyricsProvider` with lyrics display in Now Playing screen
- **Now Playing redesign**: restructured layout with lyrics button, compact volume slider, queue access improvements
- **Genre normalization**: play history recording now prefers Last.fm curated genre whitelist over raw provider tags

## Test plan
- [ ] Search "ambient" (or any genre) on Artists/Albums/Tracks tabs
- [ ] Verify no duplicates in search results
- [ ] Verify short queries (<3 chars) only do name search
- [ ] Check "Artists You May Like" surfaces relevant artists (especially with Deezer)
- [ ] Check "Albums You May Like" uses enriched genres for scoring
- [ ] Browse Library artists tab, verify background enrichment runs (check logcat for "LastFmEnricher")
- [ ] Test lyrics display in Now Playing
- [ ] Verify app works without Last.fm API key configured