### PR TITLE
Car route unify + Follow Me, Smart Mix, and Sendspin battery fixes

### DIFF
--- a/app/src/main/java/net/asksakis/massdroidv2/service/FollowMeService.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/service/FollowMeService.kt
@@ -106,7 +106,13 @@ class FollowMeService : Service() {
         ).also { it.start() }
 
         // Hold the foreground notification only while Follow Me is enabled; tear down when disabled.
+        // Gate on load() first: config starts as the disabled-by-default value and is populated
+        // asynchronously from disk. On a START_STICKY background restart there is no Activity to load
+        // it early, so acting on the default enabled=false here would call stopSelf() and the service
+        // would never come back (sticky restart does not fire again after an explicit stop). Awaiting
+        // load() makes the first collected value authoritative and closes that suicide race.
         configJob = scope.launch {
+            proximityConfigStore.load()
             proximityConfigStore.config
                 .map { it.enabled }
                 .distinctUntilChanged()

--- a/app/src/main/java/net/asksakis/massdroidv2/service/ProximityController.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/service/ProximityController.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -97,7 +98,6 @@ class ProximityController(
             androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
         )
         observeProximityConfig()
-        observeBluetoothState()
         noRoomStopController.start()
     }
 
@@ -210,39 +210,31 @@ class ProximityController(
             var wasEnabled = false
             var roomCount = 0
             var roomHash = 0
-            proximityConfigStore.config.collect { config ->
-                val shouldRun = shouldRunProximity(config)
-                val currentHash = config.rooms.sumOf { it.beaconProfiles.size + it.id.hashCode() }
-                val structureChanged = config.enabled != wasEnabled || config.rooms.size != roomCount || currentHash != roomHash
-                wasEnabled = config.enabled
-                roomCount = config.rooms.size
-                roomHash = currentHash
-                if (shouldRun && (structureChanged || proximityJob?.isActive != true)) {
-                    startProximityEngine()
-                } else if (!shouldRun) {
-                    stopEngine()
-                }
-            }
-        }
-    }
-
-    private fun observeBluetoothState() {
-        scope.launch {
-            try {
-                proximityScanner.observeBluetoothState()
-                    .distinctUntilChanged()
-                    .collect { enabled ->
-                        if (enabled) return@collect
-
-                        val config = proximityConfigStore.config.value
-                        if (!config.enabled) return@collect
-
-                        Log.d(TAG, "Bluetooth turned off: disabling Follow Me")
-                        proximityConfigStore.update { it.copy(enabled = false) }
+            var wasBtOn = true
+            // Bluetooth is a RUNTIME gate, not a persisted toggle. While BT is off we stop scanning
+            // but keep the user's enabled intent in config, so a BT flap (common on car connect) no
+            // longer permanently disables Follow Me: it resumes automatically when BT returns. The
+            // settings UI already surfaces this paused state ("Bluetooth is off. Turn it on to detect
+            // room changes.") off config.enabled && !btEnabled.
+            combine(
+                proximityConfigStore.config,
+                proximityScanner.observeBluetoothState().distinctUntilChanged(),
+            ) { config, btOn -> config to btOn }
+                .collect { (config, btOn) ->
+                    val shouldRun = shouldRunProximity(config) && btOn
+                    val currentHash = config.rooms.sumOf { it.beaconProfiles.size + it.id.hashCode() }
+                    val structureChanged = config.enabled != wasEnabled ||
+                        config.rooms.size != roomCount || currentHash != roomHash || btOn != wasBtOn
+                    wasEnabled = config.enabled
+                    roomCount = config.rooms.size
+                    roomHash = currentHash
+                    wasBtOn = btOn
+                    if (shouldRun && (structureChanged || proximityJob?.isActive != true)) {
+                        startProximityEngine()
+                    } else if (!shouldRun) {
+                        stopEngine()
                     }
-            } catch (e: Exception) {
-                Log.w(TAG, "Bluetooth state observer failed: ${e.message}")
-            }
+                }
         }
     }
 

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/BtRoute.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/BtRoute.kt
@@ -32,3 +32,15 @@ internal fun AudioManager.soleBluetoothSinkName(): String? =
         .filter { isBluetoothSink(it.type) }
         .singleOrNull()
         ?.productName?.toString()
+
+/**
+ * `bt:NAME` route keys for EVERY connected Bluetooth sink (there can be several during a connect
+ * handshake, e.g. a head unit's A2DP + LE endpoints, or the car plus paired buds). Used by the
+ * car-audio pin to decide "is a car-flagged device connected?" without depending on the single
+ * routed name, which is transiently null while the Oboe stream settles on connect.
+ */
+internal fun AudioManager.connectedBtSinkKeys(): List<String> =
+    getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+        .filter { isBluetoothSink(it.type) }
+        .mapNotNull { it.productName?.toString() }
+        .map { "bt:$it" }

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinManager.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinManager.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import net.asksakis.massdroidv2.data.websocket.SessionEventBus
 
 class SendspinManager(
@@ -44,6 +46,12 @@ class SendspinManager(
         // VOLUME_FADE_SEC (~150ms), not the snappy mute fade.
         private const val DUCK_GAIN = 0.1f
         private const val HEARTBEAT_INTERVAL_MS = 2000L
+        // After stream/end, wait this long before fully releasing the audio
+        // resources (Oboe output, wake + Wi-Fi locks). A normal track change is
+        // stream/end -> stream/start within ~1-3s and cancels the teardown; only a
+        // real stop (player deselect / group leave, no stream/start follows) lets
+        // it fire. Kept conservative so track gaps never churn the output.
+        private const val IDLE_TEARDOWN_GRACE_MS = 15_000L
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -65,6 +73,32 @@ class SendspinManager(
 
     private val _enabled = MutableStateFlow(false)
     val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
+
+    // Whether the phone is actively an audio OUTPUT (a protocol stream is live).
+    // Distinct from [connectionState]: the client stays connected/STREAMING as an
+    // available player even after playback moves elsewhere, but audio resources
+    // (Oboe output, wake + Wi-Fi locks) must only be held while this is true. The
+    // controller observes this to acquire/release those locks. Set true on
+    // stream/start; set false after the [IDLE_TEARDOWN_GRACE_MS] grace once a
+    // stream/end is not followed by a new stream. See the idle-teardown below.
+    private val _audioResourcesActive = MutableStateFlow(false)
+    val audioResourcesActive: StateFlow<Boolean> = _audioResourcesActive.asStateFlow()
+
+    // Serializes the stream/start, stream/end-teardown, stop, and engine-swap
+    // lifecycle transitions so a grace-timer teardown cannot release the engine
+    // while a concurrent stream/start is configuring it. [streamEpoch] bumps on
+    // every such transition; a pending teardown captures it and no-ops if stale.
+    private val lifecycleMutex = Mutex()
+    @Volatile private var streamEpoch = 0L
+    private var idleTeardownJob: Job? = null
+
+    // Maps the active engine's output-active transitions to [_audioResourcesActive]
+    // so the controller holds wake + Wi-Fi locks only while audio actually flows:
+    // a long pause / idle gap releases them (engine stays configured, resume
+    // re-acquires). Wired on both engines and re-wired on swap.
+    private val outputActiveHandler: (Boolean) -> Unit = { active ->
+        _audioResourcesActive.value = active
+    }
 
     // Server-pushed volume and mute events. Consumed by the
     // SendspinVolumeCoordinator to translate MA-side values into the phone's
@@ -136,6 +170,10 @@ class SendspinManager(
     private var clientName: String = ""
 
     init {
+        // Both engines exist for the app's lifetime (swapped on group join/leave);
+        // wire the output-active handler on each so locks track playback on either.
+        (directEngine as? SendspinPlaybackEngine)?.onOutputActiveChanged = outputActiveHandler
+        (syncEngine as? SendspinPlaybackEngine)?.onOutputActiveChanged = outputActiveHandler
         scope.launch {
             sessionEventBus.resets.collect {
                 if (_enabled.value || _connectionState.value != SendspinState.DISCONNECTED) {
@@ -223,7 +261,7 @@ class SendspinManager(
         client.refresh()
     }
 
-    private fun handleIncoming(incoming: SendspinIncoming) {
+    private suspend fun handleIncoming(incoming: SendspinIncoming) {
         when (incoming) {
             is SendspinIncoming.AuthOk -> {
                 Log.d(TAG, "Auth OK, sending hello")
@@ -296,7 +334,15 @@ class SendspinManager(
                 Log.d("sendspindbg", ">>> group/update")
             }
 
-            is SendspinIncoming.StreamStart -> {
+            is SendspinIncoming.StreamStart -> lifecycleMutex.withLock {
+                // A new stream cancels any pending idle teardown (this is the
+                // normal track-change stream/end -> stream/start). Bump the epoch
+                // so a teardown already past its delay() no-ops instead of racing
+                // the configure() below.
+                streamEpoch++
+                idleTeardownJob?.cancel()
+                idleTeardownJob = null
+                _audioResourcesActive.value = true
                 val info = incoming.payload.player
                 val startType = if (hasActiveProtocolStream) ProtocolStartType.CONTINUATION else ProtocolStartType.NEW_STREAM
                 Log.d("sendspindbg", ">>> stream/start $startType ${info.codec} ${info.sampleRate}Hz buf=${audio.bufferDurationMs()}ms sync=${audio.syncState}")
@@ -321,10 +367,33 @@ class SendspinManager(
             }
 
             is SendspinIncoming.StreamEnd -> {
-                Log.d("sendspindbg", ">>> stream/end proto_active=$hasActiveProtocolStream buf=${audio.bufferDurationMs()}ms sync=${audio.syncState}")
-                hasActiveProtocolStream = false
-                lastStreamInfo = null
-                audio.onStreamEnd()
+                val myEpoch = lifecycleMutex.withLock {
+                    Log.d("sendspindbg", ">>> stream/end proto_active=$hasActiveProtocolStream buf=${audio.bufferDurationMs()}ms sync=${audio.syncState}")
+                    hasActiveProtocolStream = false
+                    lastStreamInfo = null
+                    audio.onStreamEnd()
+                    idleTeardownJob?.cancel()
+                    ++streamEpoch
+                }
+                // Full audio-resource teardown after a grace window IF no new
+                // stream arrives (real stop / player deselect, not a track change).
+                // engine.release() closes the Oboe output + MediaCodec and joins the
+                // producer (configured=false, so the next stream/start rebuilds via
+                // the tested full configure path); the client stays connected as an
+                // available player. Epoch-guarded so a stream/start, stop, or engine
+                // swap during the grace makes this a no-op.
+                idleTeardownJob = scope.launch {
+                    delay(IDLE_TEARDOWN_GRACE_MS)
+                    lifecycleMutex.withLock {
+                        if (streamEpoch != myEpoch || hasActiveProtocolStream) return@withLock
+                        if (_connectionState.value == SendspinState.DISCONNECTED ||
+                            _connectionState.value == SendspinState.CONNECTING
+                        ) return@withLock
+                        Log.d(TAG, "Sendspin idle ${IDLE_TEARDOWN_GRACE_MS}ms after stream/end: releasing audio resources (client stays connected)")
+                        engine.release()
+                        _audioResourcesActive.value = false
+                    }
+                }
             }
 
             is SendspinIncoming.StreamClear -> {
@@ -569,6 +638,12 @@ class SendspinManager(
         // (stops its playback thread + AudioTrack), then wire up the incoming
         // one. The next stream/start (configure) sets it up fresh — a group
         // join/leave is already a hard relock boundary.
+        // Invalidate any pending idle teardown: this swap releases the outgoing
+        // engine itself, and the epoch bump keeps a mid-delay teardown from
+        // racing/double-releasing the freshly swapped-in engine.
+        idleTeardownJob?.cancel()
+        idleTeardownJob = null
+        streamEpoch++
         val carrySyncDelay = engine.syncDelayMs
         val carryAcoustic = engine.routeAcousticExtraUs
         engine.onSyncStateChanged = null
@@ -770,6 +845,12 @@ class SendspinManager(
     }
 
     fun stop() {
+        // Invalidate any pending idle teardown (epoch bump makes a mid-delay
+        // teardown no-op under the mutex; releaseInternal is idempotent anyway).
+        idleTeardownJob?.cancel()
+        idleTeardownJob = null
+        streamEpoch++
+        _audioResourcesActive.value = false
         hasActiveProtocolStream = false
         lastStreamInfo = null
         _enabled.value = false

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinPlaybackEngine.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinPlaybackEngine.kt
@@ -267,6 +267,13 @@ abstract class SendspinPlaybackEngine(context: Context) : SendspinAudioEngine {
         private set
     var onRoutingChanged: (() -> Unit)? = null
 
+    // Fires when the native output transitions between actively-running and
+    // idle-stopped (power-save). The manager maps this to audioResourcesActive so
+    // the wake + Wi-Fi locks are held only while audio is really flowing: a long
+    // pause or an inter-track/idle gap releases them (the engine stays configured,
+    // ring preserved), and resume re-acquires. Distinct from stream/end teardown.
+    var onOutputActiveChanged: ((Boolean) -> Unit)? = null
+
     // Detects output route changes (Oboe has no routing listener). If our bound
     // device disappears (disconnect / BT switch) we reopen the native stream
     // onto the new default route (self-heal — Oboe Shared streams do not
@@ -615,6 +622,7 @@ abstract class SendspinPlaybackEngine(context: Context) : SendspinAudioEngine {
         outputPausedForIdle = true
         playbackActive = false      // producer loop exits
         nativeOutput.pauseStream()  // real-time HAL callback stops firing
+        onOutputActiveChanged?.invoke(false)  // release wake + Wi-Fi locks
     }
 
     /** Restart the output + producer if they were stopped for idle. */
@@ -625,6 +633,7 @@ abstract class SendspinPlaybackEngine(context: Context) : SendspinAudioEngine {
         nativeOutput.resumeStream()
         playbackActive = true
         ensurePlaybackThread()
+        onOutputActiveChanged?.invoke(true)  // re-acquire wake + Wi-Fi locks
         Log.d(TAG, "Output resumed from idle stop")
     }
 

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
@@ -67,6 +67,12 @@ class SendspinVolumeCoordinator(
     private val currentOutputDeviceType: () -> Int?,
     /** Current BT output device route key (`bt:NAME`), or null if not on BT. */
     private val currentBtRouteKey: () -> String?,
+    /**
+     * Authoritative routed BT sink key (`bt:NAME`) from the Oboe stream binding ONLY, with no
+     * connected-sink fallback. Null the moment the stream unbinds from a BT sink. Used for the
+     * car-session exit confirmation (a lingering "connected" A2DP device must not abort a restore).
+     */
+    private val currentRoutedBtSinkKey: () -> String?,
     /** Route keys flagged as car audio (full volume on connect, no bridge). */
     private val carAudioDevicesFlow: Flow<Set<String>>,
     /** Record a BT route key as seen (for the car-audio picker). */
@@ -114,11 +120,6 @@ class SendspinVolumeCoordinator(
         // pushed. Sized above real-world WS round-trips (in-car cellular ~2s).
         private const val ECHO_EXPIRY_MS = 6_000L
         private const val MAX_PENDING_ECHOES = 24
-        // Car-pin retry backstop: re-check the car route this often, up to this long, while a BT
-        // sink is connected but the car session hasn't entered (routed name / device list still
-        // settling on connect). Sized to cover a slow A2DP handshake without a long busy loop.
-        private const val CAR_PIN_RETRY_INTERVAL_MS = 200L
-        private const val CAR_PIN_RETRY_TIMEOUT_MS = 3_000L
     }
 
     private data class PendingEcho(val pct: Int, val atMs: Long)
@@ -161,11 +162,10 @@ class SendspinVolumeCoordinator(
     private data class CarSession(val routeKey: String, val preCarVolume: Int)
     @Volatile private var carSession: CarSession? = null
     private val carLock = Any()
-    // Pending debounced exit of the car session (cancelled by a flap reconnect).
+    // Pending settle-windowed exit of the car session (aborted at expiry if still routed to car).
     @Volatile private var carLockClearJob: Job? = null
-    // Bounded poll that re-tries the car pin while the route settles on connect
-    // (cancelled once the session enters, on route loss, or on stop).
-    @Volatile private var carPinRetryJob: Job? = null
+    // Last BT route key recorded for the picker, to dedupe recordKnownBtDevice launches.
+    @Volatile private var lastSeenBtKey: String? = null
     @Volatile private var awaitingBaseline: Boolean = true
     @Volatile private var lastKnownMaVolume: Int = 100
     // THE canonical "remembered Sendspin volume": the phone-route level. Persisted
@@ -219,74 +219,74 @@ class SendspinVolumeCoordinator(
     }
 
     /**
-     * The output route just settled on a BT device. Records it for the car-audio
-     * picker and re-evaluates the car session (enters/affirms CarActive if the
-     * route is car-flagged).
-     */
-    fun onBtRouteConnected() {
-        currentBtRouteKey()?.let { key -> scope?.launch { recordKnownBtDevice(key) } }
-        evaluateCarRoute()
-        // Backstop for the connect-settling window: if the car session hasn't entered yet
-        // (the car device / routed name isn't resolvable at this instant), poll briefly.
-        scheduleCarPinRetryIfPending()
-    }
-
-    /**
-     * Enter or affirm the car session for the CURRENT route. Idempotent and
-     * self-determining from [currentBtRouteKey], so it is safe to call from route
-     * events AND from the clientId / car-devices flow collectors — covering
-     * cold-start (already in the car at launch) and the late-arriving Sendspin
-     * player id, neither of which fires a route transition.
+     * Single route-state entry point. EVERY route observer (AudioManager device callback /
+     * checkRouteChange, ACTION_AUDIO_BECOMING_NOISY, native Oboe re-stabilize) calls this on any
+     * change, with no connect/lost distinction. All car-session transitions derive from one truth
+     * here, which is why a source can no longer "forget" to notify and drop/revert the pin:
      *
-     * State machine: NoCar -> CarActive on the first connect to a car-flagged
-     * route (capture pre-car volume, lock transport, pin to 100%). A flap
-     * reconnect (same routeKey already CarActive) only re-affirms the lock and
-     * cancels a pending exit — it never re-pins or re-captures.
+     * - ENTER (rising, optimistic + prompt): no session and a car-flagged sink is the current
+     *   output ([resolveCarKey], routed-or-connected so it catches the connect-settling window) ->
+     *   capture pre-car volume, lock transport, pin 100%, ONCE.
+     * - STAY (session active AND still routed to the car): cancel any pending exit (absorbs a flap).
+     * - EXIT (session active AND not routed to the car): start/keep a settle timer; at expiry it
+     *   re-checks the AUTHORITATIVE routed truth ([routedCarActive]) and only then releases the
+     *   lock + restores the pre-car volume. A connect-handshake flap re-binds within the window, so
+     *   the re-check aborts the exit. (Replaces the old connect/lost split + reconnect-cancel + retry.)
      */
-    private fun evaluateCarRoute() {
-        val key = resolveCarKey() ?: return
-        val id = cachedSendspinPlayerId ?: return  // re-runs once the id flow emits
-        val entered: Boolean
-        synchronized(carLock) {
-            carLockClearJob?.cancel()
-            // Lock all transport/UI to the phone (Sendspin) while the car is
-            // connected, so play/pause/next never leaks to a remote player.
-            playerRepository.setSelectionLock(PlayerSelectionLock(id, CAR_LOCK_REASON))
-            entered = carSession?.routeKey != key
-            if (entered) {
-                // Capture the pre-car volume from phoneVolume (the last genuine
-                // phone-route level), NOT lastKnownMaVolume: on a BT (re)connect an
-                // absolute-volume speaker pushes its stored level (often the pinned
-                // 100%) into lastKnownMaVolume just before we recognise the car, which
-                // would capture 100 and make the restore a no-op. phoneVolume is frozen
-                // while BT is connected, so it holds the real pre-car level. On a
-                // car->car switch carry the ORIGINAL pre-car level forward.
-                val preCar = carSession?.preCarVolume ?: phoneVolume
-                carSession = CarSession(key, preCar)
+    fun onRouteChanged() {
+        // Record any seen BT device for the car-audio picker (deduped so a chatty route stream
+        // doesn't spawn a launch per event).
+        currentBtRouteKey()?.let { seen ->
+            if (seen != lastSeenBtKey) {
+                lastSeenBtKey = seen
+                scope?.launch { recordKnownBtDevice(seen) }
             }
         }
-        if (!entered) {
-            Log.d(TAG, "car-audio $key reconnected (flap) -> hold")
-            return
+        val id = cachedSendspinPlayerId
+        val pinKey: String? = synchronized(carLock) {
+            when {
+                carSession == null -> {
+                    val key = resolveCarKey() ?: return
+                    if (id == null) return  // re-runs once the id flow emits
+                    carLockClearJob?.cancel()
+                    carLockClearJob = null
+                    // Capture pre-car from phoneVolume (the frozen-while-BT phone-route level), NOT
+                    // lastKnownMaVolume which an absolute-volume speaker overwrites with its own
+                    // (often 100%) level on connect, making the restore a no-op.
+                    carSession = CarSession(key, phoneVolume)
+                    playerRepository.setSelectionLock(PlayerSelectionLock(id, CAR_LOCK_REASON))
+                    key
+                }
+                routedCarActive() -> {
+                    // Still on the car (or a flap just re-bound): re-affirm the lock, drop any exit.
+                    carLockClearJob?.cancel()
+                    carLockClearJob = null
+                    id?.let { playerRepository.setSelectionLock(PlayerSelectionLock(it, CAR_LOCK_REASON)) }
+                    null
+                }
+                else -> {
+                    scheduleCarExit()
+                    null
+                }
+            }
         }
-        Log.d(TAG, "car-audio $key connected -> pin 100% (pre-car ${carSession?.preCarVolume}%)")
-        // Pin to 100% via the normal volume path (MA + STREAM_MUSIC), once.
-        writeStreamMusic(100)
-        recordLocalPush(100)
-        playerRepository.applyVolumeOptimistic(id, 100)
-        launchPushToServer(id, 100, reason = "car-pin")
+        if (pinKey != null && id != null) {
+            Log.d(TAG, "car-audio $pinKey active -> pin 100% (pre-car ${carSession?.preCarVolume}%)")
+            // Pin to 100% via the normal volume path (MA + STREAM_MUSIC), once.
+            writeStreamMusic(100)
+            recordLocalPush(100)
+            playerRepository.applyVolumeOptimistic(id, 100)
+            launchPushToServer(id, 100, reason = "car-pin")
+        }
     }
 
     /**
-     * The car-flagged route key to act on, or null if the current output is not a car device.
-     *
-     * The car pin cares whether a car-flagged device is CONNECTED, not which single device the
-     * Oboe stream is currently bound to. Resolving from the routed name alone was the intermittent
-     * "volume didn't go to 100%" bug: at connect the routed name lags (null while the stream
-     * settles) and the sole-sink fallback returns null when more than one BT sink is momentarily
-     * present, so [currentBtRouteKey] is transiently null and the one-shot pin was skipped with no
-     * retry. So: honor a resolved routed key exactly (a known non-car device -> no pin); only when
-     * it is still null fall back to any connected car-flagged sink.
+     * The car-flagged route key to ENTER on, or null if the current output is not a car device.
+     * Optimistic (routed-or-connected): honors a resolved routed key exactly (a known non-car
+     * device -> no pin), and only when the routed name is still null (settling on connect) falls
+     * back to any connected car-flagged sink. The connected-sink fallback is safe for ENTER (we are
+     * connecting) but must NOT be used for exit (a lingering "connected" device lags a real
+     * disconnect) - the exit uses [routedCarActive] instead.
      */
     private fun resolveCarKey(): String? {
         val routed = currentBtRouteKey()
@@ -294,64 +294,27 @@ class SendspinVolumeCoordinator(
         return audioManager.connectedBtSinkKeys().firstOrNull { it in carAudioDevices }
     }
 
-    /**
-     * While a BT sink is connected but no car session has entered yet, briefly re-run
-     * [evaluateCarRoute] so a car device whose routed name / device list is still settling at the
-     * connect instant is not permanently missed (nothing else re-triggers the one-shot pin while
-     * the device stays connected). Bounded and cancellable: stops as soon as the session enters,
-     * the timeout elapses, or the BT sink is gone.
-     */
-    private fun scheduleCarPinRetryIfPending() {
-        if (!audioManager.anyBluetoothSinkConnected()) return
-        // Guard the check-then-launch under carLock (same monitor as the carSession/carLockClearJob
-        // transitions): callers reach this from the controller's IO scope while the coordinator's
-        // own collectors run on the Main scope, so an unguarded cancel+assign could leak a job.
-        synchronized(carLock) {
-            if (carSession != null) return
-            carPinRetryJob?.cancel()
-            carPinRetryJob = scope?.launch {
-                var waited = 0L
-                while (waited < CAR_PIN_RETRY_TIMEOUT_MS &&
-                    carSession == null &&
-                    audioManager.anyBluetoothSinkConnected()
-                ) {
-                    delay(CAR_PIN_RETRY_INTERVAL_MS)
-                    waited += CAR_PIN_RETRY_INTERVAL_MS
-                    evaluateCarRoute()
-                }
-            }
-        }
-    }
+    /** True when the Oboe stream is bound RIGHT NOW to a car-flagged sink (authoritative exit truth). */
+    private fun routedCarActive(): Boolean = currentRoutedBtSinkKey()?.let { it in carAudioDevices } ?: false
 
     /**
-     * The output route left an external sink (BT dropped to phone speaker).
-     * Schedules a debounced exit of the car session: a genuine disconnect ends it
-     * after [CAR_LOCK_CLEAR_DEBOUNCE_MS] (release lock + restore pre-car volume),
-     * but a flap reconnect ([onBtRouteConnected]) cancels the exit so transport
-     * never leaks to a remote player in the gap.
+     * Begin (or keep) the settle-windowed car-session exit. Must be called under [carLock]. At
+     * expiry it re-checks [routedCarActive]: a connect flap that re-bound within the window aborts
+     * the exit, a durable disconnect proceeds to release the lock + restore the pre-car volume.
      */
-    fun onBtRouteLost() {
-        carPinRetryJob?.cancel()
-        synchronized(carLock) {
-            if (carSession == null) return
-            // Don't restart a countdown that's already running: this fires from BOTH
-            // the fast "becoming noisy" signal AND the (much later) OS route-left-BT
-            // detection — restarting would push the restore back to the slow signal.
-            // The first trigger's timer stands; a reconnect (evaluateCarRoute) cancels
-            // it for flap protection. No route re-check here: both route signals lag
-            // ~8s on disconnect, so we rely on the reconnect-cancel instead.
-            if (carLockClearJob?.isActive == true) return
-            carLockClearJob = scope?.launch {
-                delay(CAR_LOCK_CLEAR_DEBOUNCE_MS)
-                val ended: CarSession
-                synchronized(carLock) {
-                    ended = carSession ?: return@launch
-                    carSession = null
-                    playerRepository.setSelectionLock(null)
-                }
-                Log.d(TAG, "car-audio gone -> release lock + restore ${ended.preCarVolume}%")
-                restoreCarVolume(ended.preCarVolume)
+    private fun scheduleCarExit() {
+        if (carLockClearJob?.isActive == true) return
+        carLockClearJob = scope?.launch {
+            delay(CAR_LOCK_CLEAR_DEBOUNCE_MS)
+            val ended: CarSession
+            synchronized(carLock) {
+                if (routedCarActive()) return@launch  // came back within the window -> flap, abort
+                ended = carSession ?: return@launch
+                carSession = null
+                playerRepository.setSelectionLock(null)
             }
+            Log.d(TAG, "car-audio gone -> release lock + restore ${ended.preCarVolume}%")
+            restoreCarVolume(ended.preCarVolume)
         }
     }
 
@@ -403,13 +366,13 @@ class SendspinVolumeCoordinator(
         jobs += coroutineScope.launch {
             // Re-evaluate on flag changes too: flagging the currently-connected
             // device as car audio takes effect immediately (no reconnect needed).
-            carAudioDevicesFlow.collect { carAudioDevices = it; evaluateCarRoute() }
+            carAudioDevicesFlow.collect { carAudioDevices = it; onRouteChanged() }
         }
         jobs += coroutineScope.launch {
             // The Sendspin player id arrives async; re-evaluate so a cold-start
             // already in the car locks/pins once the id is known (covers the
             // route-already-settled case that fires no transition).
-            sendspinClientIdFlow.collect { id -> cachedSendspinPlayerId = id; evaluateCarRoute() }
+            sendspinClientIdFlow.collect { id -> cachedSendspinPlayerId = id; onRouteChanged() }
         }
         jobs += coroutineScope.launch {
             serverVolumeEvents.collect { pct -> onServerVolumeEvent(pct) }
@@ -426,8 +389,6 @@ class SendspinVolumeCoordinator(
         synchronized(carLock) {
             carLockClearJob?.cancel()
             carLockClearJob = null
-            carPinRetryJob?.cancel()
-            carPinRetryJob = null
             carSession = null
             // Release a held car lock so a stopped Sendspin can't pin player selection.
             if (playerRepository.selectionLock.value?.reason == CAR_LOCK_REASON) {

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
@@ -114,6 +114,11 @@ class SendspinVolumeCoordinator(
         // pushed. Sized above real-world WS round-trips (in-car cellular ~2s).
         private const val ECHO_EXPIRY_MS = 6_000L
         private const val MAX_PENDING_ECHOES = 24
+        // Car-pin retry backstop: re-check the car route this often, up to this long, while a BT
+        // sink is connected but the car session hasn't entered (routed name / device list still
+        // settling on connect). Sized to cover a slow A2DP handshake without a long busy loop.
+        private const val CAR_PIN_RETRY_INTERVAL_MS = 200L
+        private const val CAR_PIN_RETRY_TIMEOUT_MS = 3_000L
     }
 
     private data class PendingEcho(val pct: Int, val atMs: Long)
@@ -158,6 +163,9 @@ class SendspinVolumeCoordinator(
     private val carLock = Any()
     // Pending debounced exit of the car session (cancelled by a flap reconnect).
     @Volatile private var carLockClearJob: Job? = null
+    // Bounded poll that re-tries the car pin while the route settles on connect
+    // (cancelled once the session enters, on route loss, or on stop).
+    @Volatile private var carPinRetryJob: Job? = null
     @Volatile private var awaitingBaseline: Boolean = true
     @Volatile private var lastKnownMaVolume: Int = 100
     // THE canonical "remembered Sendspin volume": the phone-route level. Persisted
@@ -216,9 +224,11 @@ class SendspinVolumeCoordinator(
      * route is car-flagged).
      */
     fun onBtRouteConnected() {
-        val key = currentBtRouteKey() ?: return
-        scope?.launch { recordKnownBtDevice(key) }
+        currentBtRouteKey()?.let { key -> scope?.launch { recordKnownBtDevice(key) } }
         evaluateCarRoute()
+        // Backstop for the connect-settling window: if the car session hasn't entered yet
+        // (the car device / routed name isn't resolvable at this instant), poll briefly.
+        scheduleCarPinRetryIfPending()
     }
 
     /**
@@ -234,8 +244,7 @@ class SendspinVolumeCoordinator(
      * cancels a pending exit — it never re-pins or re-captures.
      */
     private fun evaluateCarRoute() {
-        val key = currentBtRouteKey() ?: return
-        if (key !in carAudioDevices) return
+        val key = resolveCarKey() ?: return
         val id = cachedSendspinPlayerId ?: return  // re-runs once the id flow emits
         val entered: Boolean
         synchronized(carLock) {
@@ -269,6 +278,46 @@ class SendspinVolumeCoordinator(
     }
 
     /**
+     * The car-flagged route key to act on, or null if the current output is not a car device.
+     *
+     * The car pin cares whether a car-flagged device is CONNECTED, not which single device the
+     * Oboe stream is currently bound to. Resolving from the routed name alone was the intermittent
+     * "volume didn't go to 100%" bug: at connect the routed name lags (null while the stream
+     * settles) and the sole-sink fallback returns null when more than one BT sink is momentarily
+     * present, so [currentBtRouteKey] is transiently null and the one-shot pin was skipped with no
+     * retry. So: honor a resolved routed key exactly (a known non-car device -> no pin); only when
+     * it is still null fall back to any connected car-flagged sink.
+     */
+    private fun resolveCarKey(): String? {
+        val routed = currentBtRouteKey()
+        if (routed != null) return routed.takeIf { it in carAudioDevices }
+        return audioManager.connectedBtSinkKeys().firstOrNull { it in carAudioDevices }
+    }
+
+    /**
+     * While a BT sink is connected but no car session has entered yet, briefly re-run
+     * [evaluateCarRoute] so a car device whose routed name / device list is still settling at the
+     * connect instant is not permanently missed (nothing else re-triggers the one-shot pin while
+     * the device stays connected). Bounded and cancellable: stops as soon as the session enters,
+     * the timeout elapses, or the BT sink is gone.
+     */
+    private fun scheduleCarPinRetryIfPending() {
+        if (carSession != null || !audioManager.anyBluetoothSinkConnected()) return
+        carPinRetryJob?.cancel()
+        carPinRetryJob = scope?.launch {
+            var waited = 0L
+            while (waited < CAR_PIN_RETRY_TIMEOUT_MS &&
+                carSession == null &&
+                audioManager.anyBluetoothSinkConnected()
+            ) {
+                delay(CAR_PIN_RETRY_INTERVAL_MS)
+                waited += CAR_PIN_RETRY_INTERVAL_MS
+                evaluateCarRoute()
+            }
+        }
+    }
+
+    /**
      * The output route left an external sink (BT dropped to phone speaker).
      * Schedules a debounced exit of the car session: a genuine disconnect ends it
      * after [CAR_LOCK_CLEAR_DEBOUNCE_MS] (release lock + restore pre-car volume),
@@ -276,6 +325,7 @@ class SendspinVolumeCoordinator(
      * never leaks to a remote player in the gap.
      */
     fun onBtRouteLost() {
+        carPinRetryJob?.cancel()
         synchronized(carLock) {
             if (carSession == null) return
             // Don't restart a countdown that's already running: this fires from BOTH
@@ -370,6 +420,8 @@ class SendspinVolumeCoordinator(
         synchronized(carLock) {
             carLockClearJob?.cancel()
             carLockClearJob = null
+            carPinRetryJob?.cancel()
+            carPinRetryJob = null
             carSession = null
             // Release a held car lock so a stopped Sendspin can't pin player selection.
             if (playerRepository.selectionLock.value?.reason == CAR_LOCK_REASON) {

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
@@ -67,12 +67,6 @@ class SendspinVolumeCoordinator(
     private val currentOutputDeviceType: () -> Int?,
     /** Current BT output device route key (`bt:NAME`), or null if not on BT. */
     private val currentBtRouteKey: () -> String?,
-    /**
-     * Authoritative routed BT sink key (`bt:NAME`) from the Oboe stream binding ONLY, with no
-     * connected-sink fallback. Null the moment the stream unbinds from a BT sink. Used for the
-     * car-session exit confirmation (a lingering "connected" A2DP device must not abort a restore).
-     */
-    private val currentRoutedBtSinkKey: () -> String?,
     /** Route keys flagged as car audio (full volume on connect, no bridge). */
     private val carAudioDevicesFlow: Flow<Set<String>>,
     /** Record a BT route key as seen (for the car-audio picker). */
@@ -294,8 +288,22 @@ class SendspinVolumeCoordinator(
         return audioManager.connectedBtSinkKeys().firstOrNull { it in carAudioDevices }
     }
 
-    /** True when the Oboe stream is bound RIGHT NOW to a car-flagged sink (authoritative exit truth). */
-    private fun routedCarActive(): Boolean = currentRoutedBtSinkKey()?.let { it in carAudioDevices } ?: false
+    /**
+     * True when the active output is RIGHT NOW a car-flagged BT sink (authoritative exit truth).
+     *
+     * Gated on the routed device TYPE, not the routed product name: the name lags (null/"unknown")
+     * for seconds after a connect or during a reopen even while genuinely bound to the car, which
+     * made a name-based check falsely report "gone" and spuriously exit a live car session (seen in
+     * a cold-start-already-in-car log). The routed TYPE leaves BT promptly on a real disconnect (the
+     * stream rebinds to the builtin output), so it is the reliable falling edge; the connected-sink
+     * list only supplies the car identity and is consulted ONLY while the type is still BT (so its
+     * ~8s post-disconnect lag can never abort a real restore - by then the type has already left BT).
+     */
+    private fun routedCarActive(): Boolean {
+        val type = currentOutputDeviceType() ?: return false
+        if (!isBluetoothSink(type)) return false
+        return audioManager.connectedBtSinkKeys().any { it in carAudioDevices }
+    }
 
     /**
      * Begin (or keep) the settle-windowed car-session exit. Must be called under [carLock]. At

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
@@ -302,17 +302,23 @@ class SendspinVolumeCoordinator(
      * the timeout elapses, or the BT sink is gone.
      */
     private fun scheduleCarPinRetryIfPending() {
-        if (carSession != null || !audioManager.anyBluetoothSinkConnected()) return
-        carPinRetryJob?.cancel()
-        carPinRetryJob = scope?.launch {
-            var waited = 0L
-            while (waited < CAR_PIN_RETRY_TIMEOUT_MS &&
-                carSession == null &&
-                audioManager.anyBluetoothSinkConnected()
-            ) {
-                delay(CAR_PIN_RETRY_INTERVAL_MS)
-                waited += CAR_PIN_RETRY_INTERVAL_MS
-                evaluateCarRoute()
+        if (!audioManager.anyBluetoothSinkConnected()) return
+        // Guard the check-then-launch under carLock (same monitor as the carSession/carLockClearJob
+        // transitions): callers reach this from the controller's IO scope while the coordinator's
+        // own collectors run on the Main scope, so an unguarded cancel+assign could leak a job.
+        synchronized(carLock) {
+            if (carSession != null) return
+            carPinRetryJob?.cancel()
+            carPinRetryJob = scope?.launch {
+                var waited = 0L
+                while (waited < CAR_PIN_RETRY_TIMEOUT_MS &&
+                    carSession == null &&
+                    audioManager.anyBluetoothSinkConnected()
+                ) {
+                    delay(CAR_PIN_RETRY_INTERVAL_MS)
+                    waited += CAR_PIN_RETRY_INTERVAL_MS
+                    evaluateCarRoute()
+                }
             }
         }
     }

--- a/core/src/main/java/net/asksakis/massdroidv2/di/AppModule.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/di/AppModule.kt
@@ -167,19 +167,6 @@ object AppModule {
                 }
                 name?.let { "bt:$it" }
             },
-            // Authoritative "the Oboe stream is bound to this BT sink RIGHT NOW", with NO
-            // soleBluetoothSinkName fallback. Used only for the car-session EXIT confirmation:
-            // after a real disconnect Android keeps the A2DP device "connected" (so getDevices /
-            // soleBluetoothSinkName would still report it and wrongly abort the restore), but the
-            // Oboe routed device unbinds immediately - so this is the reliable falling-edge truth.
-            currentRoutedBtSinkKey = {
-                val routedType = sendspinManager.getRoutedDeviceType()
-                if (routedType != null && isBluetoothSink(routedType)) {
-                    sendspinManager.getRoutedDeviceProductName()?.let { "bt:$it" }
-                } else {
-                    null
-                }
-            },
             carAudioDevicesFlow = settingsRepository.carAudioBtDevices,
             recordKnownBtDevice = { settingsRepository.recordKnownBtDevice(it) },
         )

--- a/core/src/main/java/net/asksakis/massdroidv2/di/AppModule.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/di/AppModule.kt
@@ -167,6 +167,19 @@ object AppModule {
                 }
                 name?.let { "bt:$it" }
             },
+            // Authoritative "the Oboe stream is bound to this BT sink RIGHT NOW", with NO
+            // soleBluetoothSinkName fallback. Used only for the car-session EXIT confirmation:
+            // after a real disconnect Android keeps the A2DP device "connected" (so getDevices /
+            // soleBluetoothSinkName would still report it and wrongly abort the restore), but the
+            // Oboe routed device unbinds immediately - so this is the reliable falling-edge truth.
+            currentRoutedBtSinkKey = {
+                val routedType = sendspinManager.getRoutedDeviceType()
+                if (routedType != null && isBluetoothSink(routedType)) {
+                    sendspinManager.getRoutedDeviceProductName()?.let { "bt:$it" }
+                } else {
+                    null
+                }
+            },
             carAudioDevicesFlow = settingsRepository.carAudioBtDevices,
             recordKnownBtDevice = { settingsRepository.recordKnownBtDevice(it) },
         )

--- a/core/src/main/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackMixGenerator.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackMixGenerator.kt
@@ -56,6 +56,13 @@ private const val RESOLVED_TRACK_TTL_MS = 30L * 24 * 60 * 60 * 1000
 private const val SEED_RECENT_ARTIST_PENALTY = 0.4
 private const val SEED_RECENT_TRACK_PENALTY = 1.5
 private const val MIN_SEEDS = 2
+// Variety knob -> genre movement between consecutive mixes. Below this the next
+// mix STAYS in the recent genre family (drifting the sub-genre via exactFresh:
+// deep house -> techno -> nu-disco), avoiding whiplash to unrelated genres.
+// At/above it the mix is allowed to HOP to a different family (exploration).
+// This replaces the old always-on family-hop that jumped e.g. deep house ->
+// hard rock every run.
+private const val FAMILY_HOP_VARIETY_THRESHOLD = 0.66
 // Strictness knob -> minimum tracks.score a seed must have. At 1.0 only "loved"
 // tracks (score > 0.5) qualify; at 0.0 any non-disliked track (score >= 0).
 private const val STRICTNESS_MAX_SCORE = 0.5
@@ -63,14 +70,12 @@ private const val STRICTNESS_MAX_SCORE = 0.5
 // mix can still be built (cold-start / lightly-rated libraries).
 private const val SEED_POOL_RELAX_MIN = 6
 // Loved-track injection (comfort anchor). Discovery drives the share, with NO
-// floor: at Discovery=0 up to MAX_FRACTION of the mix may be the user's own loved
-// tracks, and at high Discovery it tapers to zero (pure discovery). Only tracks
-// scored >= MIN_SCORE qualify.
-private const val OWN_INJECT_MAX_FRACTION = 0.4
-// "Liked" floor (0.1) rather than "loved" (0.5): once narrowed to the mix's
-// genre and deduped by artist, a 0.5 floor leaves too small an in-genre pool to
-// fill the quota. Score ordering still puts the most-loved in-genre tracks first.
-private const val LOVED_INJECT_MIN_SCORE = 0.1
+// ceiling: at Discovery=0 up to MAX_FRACTION of the mix may be the user's own
+// loved tracks, and at high Discovery it tapers to zero (pure discovery). The
+// score floor for what qualifies is derived from the Strictness slider (see
+// lovedInjection), so a low Discovery no longer fills the mix with weakly-liked
+// filler.
+private const val OWN_INJECT_MAX_FRACTION = 0.30
 private const val LOVED_INJECT_POOL_LIMIT = 600
 // Injected loved tracks enter with a MID-PACK relevance so they COMPETE with the
 // seed-similars instead of dominating the front of the mix. A top score (1.0) made
@@ -380,7 +385,7 @@ class SeedTrackMixGenerator @Inject constructor(
         // favourites rotate.
         val injectCount = seedTrackInjectCount(tuning.discovery, target)
         val injected = if (injectCount > 0) {
-            lovedInjection(coherentGenres, injectCount, mixSeed, recency)
+            lovedInjection(coherentGenres, injectCount, mixSeed, recency, tuning.strictness)
         } else {
             emptyList()
         }
@@ -400,21 +405,31 @@ class SeedTrackMixGenerator @Inject constructor(
         coherentGenres: Set<String>,
         count: Int,
         mixSeed: Long,
-        recency: Recency
+        recency: Recency,
+        strictness: Double
     ): List<CandidateTrack> {
         val since = System.currentTimeMillis() - GENRE_SEED_LOOKBACK_DAYS * 24L * 60 * 60 * 1000
         val blockedKeys = recency.blockedArtistNames
             .map { LastFmTrackSimilarResolver.normalizeName(it) }
             .filter { it.isNotBlank() }
             .toSet()
-        val raw = querySeedTracks(since, LOVED_INJECT_MIN_SCORE, LOVED_INJECT_POOL_LIMIT)
+        // Floor derives from the Strictness slider, matching the seed threshold
+        // (strictness * STRICTNESS_MAX_SCORE). A low Discovery therefore reserves
+        // a slice for genuinely loved tracks, not weakly-liked (score ~0.1) filler.
+        val minScore = strictness * STRICTNESS_MAX_SCORE
+        val raw = querySeedTracks(since, minScore, LOVED_INJECT_POOL_LIMIT)
         val notRecent = raw.filter {
             it.trackUri.isNotBlank() &&
                 it.trackUri !in recency.recentMixTrackUris &&
                 LastFmTrackSimilarResolver.normalizeName(it.artistName) !in blockedKeys
         }
+        // Family-aware in-genre gate (same as the discovery-candidate gate) so an
+        // injected loved track cannot reintroduce a foreign family that merely
+        // shares a noisy token with the cluster envelope.
+        val envelopeTokens = genreTokens(coherentGenres)
+        val envelopeFamilies = genreFamilies(coherentGenres)
         val inGenre = notRecent.filter { row ->
-            coherentGenres.isEmpty() || row.genres.any { normalizeGenre(it) in coherentGenres }
+            coherentGenres.isEmpty() || genreGatePasses(row.genres, envelopeFamilies, envelopeTokens)
         }
         val deduped = dedupeByArtist(inGenre).shuffled(kotlin.random.Random(mixSeed)).take(count)
         Log.d(TAG, "loved-inject: want=$count inGenrePool=${inGenre.size} -> injected ${deduped.size}")
@@ -489,18 +504,26 @@ class SeedTrackMixGenerator @Inject constructor(
         // the top-ranked seeds (steadier), high variety draws from the whole
         // tagged pool. varietyWindow spans the full 0..1 range (no plateau).
         val primaryPool = tagged.take(varietyWindow(tuning.variety, tagged.size))
-        // Genre rotation: prefer a primary whose FAMILY was not the anchor of
-        // the last few mixes (strongest hop across the user's genres), then one
-        // whose exact genres are at least new, then the full window when
-        // everything recent is in the same family.
+        // Genre movement (Variety-gated). exactFresh always rotates the sub-genre
+        // (avoid the exact genres of recent mixes) so we never lock onto one thing.
+        // The FAMILY behaviour then depends on Variety:
+        //   - below FAMILY_HOP_VARIETY_THRESHOLD: prefer a primary in the SAME
+        //     family as recent mixes (coherent adjacency drift, no whiplash),
+        //   - at/above it: prefer a DIFFERENT family (exploration hop).
+        // Either preference falls back to exactFresh, then the full window, so the
+        // pool never collapses. Track/artist cool-down (below) keeps songs fresh.
         val recentFamilies = genreFamilies(recency.recentClusterGenres)
         val exactFresh = primaryPool.filter { seed ->
             coherenceGenres(seed).none { it in recency.recentClusterGenres }
         }
-        val familyFresh = exactFresh.filter { seed ->
-            genreFamilies(coherenceGenres(seed)).none { it in recentFamilies }
+        val preferred = when {
+            recentFamilies.isEmpty() -> emptyList()
+            tuning.variety >= FAMILY_HOP_VARIETY_THRESHOLD ->
+                exactFresh.filter { seed -> genreFamilies(coherenceGenres(seed)).none { it in recentFamilies } }
+            else ->
+                exactFresh.filter { seed -> genreFamilies(coherenceGenres(seed)).any { it in recentFamilies } }
         }
-        val freshPool = familyFresh.ifEmpty { exactFresh }
+        val freshPool = preferred.ifEmpty { exactFresh }
         val primary = freshPool.ifEmpty { primaryPool }.shuffled(random).first()
         val primaryGenres = coherenceGenres(primary)
         val cluster = byArtist.filter { seed ->

--- a/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
@@ -918,6 +918,13 @@ class SendspinAudioController(
                 Log.d(TAG, "BT connect auto-play skipped: route did not stabilize on BT")
                 return@launch
             }
+            // A BT re-stabilization (the connect-time A2DP flap re-binds the sink under a new
+            // device id, same product) must cancel any pending car-session exit that a transient
+            // BECOMING_NOISY started, otherwise the debounced exit tears down the car pin and
+            // restores the pre-car volume off 100%. checkRouteChange fires onBtRouteConnected on a
+            // route-transition reconnect, but this native-reopen re-stabilize path did not, so wire
+            // it here too (idempotent: re-affirms the session / cancels the exit, never re-pins).
+            volumeCoordinator.onBtRouteConnected()
             if (_userIntent.value) return@launch  // already playing / intending to
             if (isInActiveCall()) {
                 Log.d(TAG, "BT connect auto-play skipped: active call/communication")

--- a/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
@@ -503,14 +503,11 @@ class SendspinAudioController(
                 recomputeAvailability()
                 Log.d(TAG, "Sendspin state: $state, isStreaming=$isStreaming, isReady=$isReady, sync=$localSyncState")
 
-                // Audio focus still tracks the STREAMING transport edge. The wake
-                // + Wi-Fi locks are NOT acquired here anymore: they follow the
-                // manager's audioResourcesActive flow (collector below), so they
-                // release once the phone stops being an actual output even though
-                // the client stays connected (STREAMING) as an available player.
-                if (!wasStreaming && transportState == SendspinState.STREAMING) {
-                    if (!hasAudioFocus) requestAudioFocus()
-                }
+                // Wake + Wi-Fi locks AND audio focus now follow the manager's
+                // audioResourcesActive flow (collector below), not this transport
+                // edge, so they release once the phone stops being an actual output
+                // even though the client stays connected (STREAMING) as an
+                // available player.
                 if (wasStreaming && transportState != SendspinState.STREAMING) {
                     Log.d(TAG, "Sendspin dropped while streaming")
                 }
@@ -537,9 +534,18 @@ class SendspinAudioController(
         // player. distinctUntilChanged so we only act on real edges.
         collectorJobs += scope.launch {
             // StateFlow is already conflated (distinct-by-equality), so collect
-            // sees only real true/false edges.
+            // sees only real true/false edges. Audio focus rides the same signal:
+            // requested while we are an actual output, abandoned on idle/deselect
+            // so other apps regain focus (voluntary abandon fires no LOSS callback,
+            // so it never triggers our own focus-loss pause path).
             sendspinManager.audioResourcesActive.collect { active ->
-                if (active) acquireLocks() else releaseLocks()
+                if (active) {
+                    acquireLocks()
+                    if (!hasAudioFocus) requestAudioFocus()
+                } else {
+                    releaseLocks()
+                    abandonAudioFocus()
+                }
             }
         }
 

--- a/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
@@ -503,12 +503,15 @@ class SendspinAudioController(
                 recomputeAvailability()
                 Log.d(TAG, "Sendspin state: $state, isStreaming=$isStreaming, isReady=$isReady, sync=$localSyncState")
 
+                // Audio focus still tracks the STREAMING transport edge. The wake
+                // + Wi-Fi locks are NOT acquired here anymore: they follow the
+                // manager's audioResourcesActive flow (collector below), so they
+                // release once the phone stops being an actual output even though
+                // the client stays connected (STREAMING) as an available player.
                 if (!wasStreaming && transportState == SendspinState.STREAMING) {
-                    acquireLocks()
                     if (!hasAudioFocus) requestAudioFocus()
                 }
                 if (wasStreaming && transportState != SendspinState.STREAMING) {
-                    releaseLocks()
                     Log.d(TAG, "Sendspin dropped while streaming")
                 }
 
@@ -523,6 +526,20 @@ class SendspinAudioController(
                     sendspinManager.onTransportFailure()
                 }
                 notifyStateChanged()
+            }
+        }
+
+        // Collector: audio-resource ownership. Wake + Wi-Fi locks are held only
+        // while the phone is an actual output (a protocol stream is live). The
+        // manager keeps this true across track changes and drops it after a grace
+        // once playback moves elsewhere, so the locks + native Oboe output are not
+        // held indefinitely while the client stays connected as an available
+        // player. distinctUntilChanged so we only act on real edges.
+        collectorJobs += scope.launch {
+            // StateFlow is already conflated (distinct-by-equality), so collect
+            // sees only real true/false edges.
+            sendspinManager.audioResourcesActive.collect { active ->
+                if (active) acquireLocks() else releaseLocks()
             }
         }
 

--- a/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
@@ -138,11 +138,11 @@ class SendspinAudioController(
                 if (sendspinPlayerId == null) return
                 Log.d(TAG, "Audio becoming noisy -> clean pause")
                 volumeCoordinator.onOutputRouteChanging()
-                // Fast disconnect signal: starts the car-session exit debounce now,
-                // ~8s before the OS finally reports the route left BT (Android keeps
-                // the A2DP device "connected" long after audio stops). A reconnect
-                // cancels it, so a flap is still absorbed.
-                volumeCoordinator.onBtRouteLost()
+                // Poke the unified car-route evaluation. If this is a real disconnect the
+                // coordinator's settle timer will confirm (Oboe no longer routed to the car) and
+                // restore the pre-car volume; a connect-handshake flap re-binds within the window
+                // and the settle re-check aborts the exit. No connect/lost distinction here.
+                volumeCoordinator.onRouteChanged()
                 ++routeChangeGeneration  // supersede any in-flight relock
                 pauseForRouteLoss()
             }
@@ -221,7 +221,7 @@ class SendspinAudioController(
                     sendspinManager.setRouteAcousticExtraUs(correctionUs)
                     sendspinManager.onOutputRouteChanged("bt:device-switch")
                     currentBtRouteKey = routeKey  // commit only after successful apply
-                    volumeCoordinator.onBtRouteConnected()
+                    volumeCoordinator.onRouteChanged()
                 }
             }
         }
@@ -236,7 +236,7 @@ class SendspinAudioController(
             sendspinManager.setRouteAcousticExtraUs(correctionUs)
             sendspinManager.onOutputRouteChanged("$oldRoute->$newRoute")
             currentBtRouteKey = if (newRoute == OutputRoute.BT) resolveBtRouteKey() else ""
-            if (newRoute == OutputRoute.BT) volumeCoordinator.onBtRouteConnected()
+            if (newRoute == OutputRoute.BT) volumeCoordinator.onRouteChanged()
         }
     }
 
@@ -267,7 +267,7 @@ class SendspinAudioController(
         sendspinManager.setMuted(false)
         // Debounced release of any car-audio selection lock (a flap reconnect
         // cancels it, so transport stays on the phone through the gap).
-        volumeCoordinator.onBtRouteLost()
+        volumeCoordinator.onRouteChanged()
         scope.launch { playerRepository.pause(id) }
     }
 
@@ -918,13 +918,12 @@ class SendspinAudioController(
                 Log.d(TAG, "BT connect auto-play skipped: route did not stabilize on BT")
                 return@launch
             }
-            // A BT re-stabilization (the connect-time A2DP flap re-binds the sink under a new
-            // device id, same product) must cancel any pending car-session exit that a transient
-            // BECOMING_NOISY started, otherwise the debounced exit tears down the car pin and
-            // restores the pre-car volume off 100%. checkRouteChange fires onBtRouteConnected on a
-            // route-transition reconnect, but this native-reopen re-stabilize path did not, so wire
-            // it here too (idempotent: re-affirms the session / cancels the exit, never re-pins).
-            volumeCoordinator.onBtRouteConnected()
+            // Poke the unified car-route evaluation once BT re-stabilizes. The connect-time A2DP
+            // flap re-binds the sink under a new AAudio device id (same product) via this native
+            // reopen path, which does not fire a checkRouteChange transition; without this poke the
+            // coordinator's settle re-check still aborts the exit (Oboe is routed to the car again),
+            // but poking here re-affirms promptly. Idempotent: never re-pins.
+            volumeCoordinator.onRouteChanged()
             if (_userIntent.value) return@launch  // already playing / intending to
             if (isInActiveCall()) {
                 Log.d(TAG, "BT connect auto-play skipped: active call/communication")

--- a/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
+++ b/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
@@ -58,6 +58,8 @@ class SendspinVolumeCoordinatorTest {
         // Mutable route view the injected lambdas read; tests flip these.
         @Volatile var routeType: Int? = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
         @Volatile var btRouteKey: String? = null
+        // Authoritative routed-only key (Oboe binding); null unless actively routed to a BT sink.
+        @Volatile var routedBtKey: String? = null
         // Current STREAM_MUSIC index getStreamVolume returns. Kept distinct from the
         // indices under test so writeStreamMusic actually calls setStreamVolume
         // (it no-ops when current == target).
@@ -82,6 +84,7 @@ class SendspinVolumeCoordinatorTest {
             playerRepository = playerRepository,
             currentOutputDeviceType = { routeType },
             currentBtRouteKey = { btRouteKey },
+            currentRoutedBtSinkKey = { routedBtKey },
             carAudioDevicesFlow = carDevicesFlow,
             recordKnownBtDevice = { recordedBt += it },
         )
@@ -94,12 +97,14 @@ class SendspinVolumeCoordinatorTest {
         fun onPhoneRoute() {
             routeType = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
             btRouteKey = null
+            routedBtKey = null
             devices = emptyArray()
         }
 
         fun onBtRoute(name: String = "MINI45864") {
             routeType = AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
             btRouteKey = "bt:$name"
+            routedBtKey = "bt:$name"
             devices = arrayOf(btSink(name))
         }
 
@@ -234,9 +239,10 @@ class SendspinVolumeCoordinatorTest {
         }
 
     @Test
-    fun carConnect_carDeviceAppearsLate_retryBackstopPins() = runTest(UnconfinedTestDispatcher()) {
+    fun carConnect_carDeviceAppearsLate_nextRoutePokeEnters() = runTest(UnconfinedTestDispatcher()) {
         // At connect only a non-car BT sink is enumerated; the car is added to the device list a
-        // moment later (slow A2DP handshake). The bounded retry must catch it and pin.
+        // moment later (slow A2DP handshake). The next route poke (device-added -> checkRouteChange)
+        // must then enter + pin (no dedicated retry job needed).
         val f = Fixture().apply {
             routeType = AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
             btRouteKey = null
@@ -249,9 +255,8 @@ class SendspinVolumeCoordinatorTest {
         advanceUntilIdle()
         f.assertNoWriteOf(idx(100)) // car not connected yet -> no pin
 
-        c.onBtRouteConnected() // schedules the retry backstop
         f.devices = arrayOf(f.btSink("Buds"), f.btSink("MINI45864")) // car settles in
-        advanceTimeBy(600) // a few retry ticks
+        c.onRouteChanged() // the device-added route poke
         advanceUntilIdle()
 
         verify { f.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, idx(100), 0) }
@@ -300,7 +305,9 @@ class SendspinVolumeCoordinatorTest {
         f.carDevicesFlow.emit(setOf(CAR_KEY)) // pre-car volume captured = phoneVolume (80)
         advanceUntilIdle()
 
-        c.onBtRouteLost()
+        // BT gone: the Oboe unbinds (routedBtKey null) and the sink leaves the device list.
+        f.onPhoneRoute()
+        c.onRouteChanged()
         advanceTimeBy(3_500) // past CAR_LOCK_CLEAR_DEBOUNCE_MS
         advanceUntilIdle()
 
@@ -319,13 +326,58 @@ class SendspinVolumeCoordinatorTest {
         f.carDevicesFlow.emit(setOf(CAR_KEY))
         advanceUntilIdle()
 
-        c.onBtRouteLost()
-        advanceTimeBy(1_000)        // mid-debounce
-        c.onBtRouteConnected()      // flap reconnect cancels the pending exit
+        f.routedBtKey = null        // transient loss: Oboe unbound (device still "connected")
+        c.onRouteChanged()          // schedules the settle exit
+        advanceTimeBy(1_000)        // mid-settle
+        f.routedBtKey = "bt:MINI45864" // flap re-binds to the car
+        c.onRouteChanged()          // routed to car again -> cancels the pending exit
         advanceTimeBy(3_500)
         advanceUntilIdle()
 
         // No restore-to-pre-car and no lock release happened.
+        f.assertNoWriteOf(idx(80))
+        verify(exactly = 0) { f.playerRepository.setSelectionLock(null) }
+    }
+
+    @Test
+    fun carDisconnect_deviceStillListedButOboeUnbound_restores() = runTest(UnconfinedTestDispatcher()) {
+        // Real disconnect: Android keeps the A2DP device in getDevices for a while, but the Oboe
+        // routed device unbinds immediately. The exit uses the routed-only truth, so the lingering
+        // "connected" device must NOT fool the settle re-check into aborting the restore.
+        val f = Fixture().apply { onBtRoute() }
+        val c = f.build()
+        c.start(backgroundScope)
+        advanceUntilIdle()
+        f.carDevicesFlow.emit(setOf(CAR_KEY))
+        advanceUntilIdle()
+
+        f.routedBtKey = null // Oboe unbound; devices still lists MINI45864 (Android lag)
+        c.onRouteChanged()
+        advanceTimeBy(3_500)
+        advanceUntilIdle()
+
+        verify { f.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, idx(80), 0) }
+        verify { f.playerRepository.setSelectionLock(null) }
+    }
+
+    @Test
+    fun carDisconnect_flapReBindsByExpiry_settleRecheckAborts() = runTest(UnconfinedTestDispatcher()) {
+        // Even with NO reconnect poke, the settle re-check must abort the exit when the Oboe has
+        // re-bound to the car by expiry (the native-reopen flap that fires no route event).
+        val f = Fixture().apply { onBtRoute() }
+        val c = f.build()
+        c.start(backgroundScope)
+        advanceUntilIdle()
+        f.carDevicesFlow.emit(setOf(CAR_KEY))
+        advanceUntilIdle()
+
+        f.routedBtKey = null   // transient unbind -> schedule exit
+        c.onRouteChanged()
+        advanceTimeBy(1_000)
+        f.routedBtKey = "bt:MINI45864" // re-bound, but NO onRouteChanged poke this time
+        advanceTimeBy(3_500)   // settle fires -> re-check sees car routed -> abort
+        advanceUntilIdle()
+
         f.assertNoWriteOf(idx(80))
         verify(exactly = 0) { f.playerRepository.setSelectionLock(null) }
     }

--- a/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
+++ b/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
@@ -211,6 +211,53 @@ class SendspinVolumeCoordinatorTest {
     }
 
     @Test
+    fun carConnect_routedNameUnresolvedWithMultipleSinks_stillPinsViaConnectedSink() =
+        runTest(UnconfinedTestDispatcher()) {
+            // The intermittent "volume didn't go to 100%" race: at connect the routed name is
+            // still null AND more than one BT sink is present, so the sole-sink fallback is null
+            // too -> currentBtRouteKey() is null. The old one-shot pin bailed with no retry.
+            val f = Fixture().apply {
+                routeType = AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+                btRouteKey = null // routed name still settling
+                devices = arrayOf(btSink("MINI45864"), btSink("Buds")) // two sinks -> not "sole"
+            }
+            val c = f.build()
+            c.start(backgroundScope)
+            advanceUntilIdle()
+
+            f.carDevicesFlow.emit(setOf(CAR_KEY)) // flags MINI45864
+            advanceUntilIdle()
+
+            // Pinned via the connected-sink match despite the unresolved routed key.
+            verify { f.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, idx(100), 0) }
+            verify { f.playerRepository.setSelectionLock(PlayerSelectionLock(PLAYER, "car_audio")) }
+        }
+
+    @Test
+    fun carConnect_carDeviceAppearsLate_retryBackstopPins() = runTest(UnconfinedTestDispatcher()) {
+        // At connect only a non-car BT sink is enumerated; the car is added to the device list a
+        // moment later (slow A2DP handshake). The bounded retry must catch it and pin.
+        val f = Fixture().apply {
+            routeType = AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+            btRouteKey = null
+            devices = arrayOf(btSink("Buds")) // a BT sink connected, but not the car yet
+        }
+        val c = f.build()
+        c.start(backgroundScope)
+        advanceUntilIdle()
+        f.carDevicesFlow.emit(setOf(CAR_KEY))
+        advanceUntilIdle()
+        f.assertNoWriteOf(idx(100)) // car not connected yet -> no pin
+
+        c.onBtRouteConnected() // schedules the retry backstop
+        f.devices = arrayOf(f.btSink("Buds"), f.btSink("MINI45864")) // car settles in
+        advanceTimeBy(600) // a few retry ticks
+        advanceUntilIdle()
+
+        verify { f.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, idx(100), 0) }
+    }
+
+    @Test
     fun carActive_serverVolume_doesNotTouchStreamMusic() = runTest(UnconfinedTestDispatcher()) {
         val f = Fixture().apply { onBtRoute() }
         val c = f.build()

--- a/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
+++ b/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
@@ -58,8 +58,6 @@ class SendspinVolumeCoordinatorTest {
         // Mutable route view the injected lambdas read; tests flip these.
         @Volatile var routeType: Int? = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
         @Volatile var btRouteKey: String? = null
-        // Authoritative routed-only key (Oboe binding); null unless actively routed to a BT sink.
-        @Volatile var routedBtKey: String? = null
         // Current STREAM_MUSIC index getStreamVolume returns. Kept distinct from the
         // indices under test so writeStreamMusic actually calls setStreamVolume
         // (it no-ops when current == target).
@@ -84,7 +82,6 @@ class SendspinVolumeCoordinatorTest {
             playerRepository = playerRepository,
             currentOutputDeviceType = { routeType },
             currentBtRouteKey = { btRouteKey },
-            currentRoutedBtSinkKey = { routedBtKey },
             carAudioDevicesFlow = carDevicesFlow,
             recordKnownBtDevice = { recordedBt += it },
         )
@@ -97,14 +94,12 @@ class SendspinVolumeCoordinatorTest {
         fun onPhoneRoute() {
             routeType = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
             btRouteKey = null
-            routedBtKey = null
             devices = emptyArray()
         }
 
         fun onBtRoute(name: String = "MINI45864") {
             routeType = AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
             btRouteKey = "bt:$name"
-            routedBtKey = "bt:$name"
             devices = arrayOf(btSink(name))
         }
 
@@ -305,7 +300,7 @@ class SendspinVolumeCoordinatorTest {
         f.carDevicesFlow.emit(setOf(CAR_KEY)) // pre-car volume captured = phoneVolume (80)
         advanceUntilIdle()
 
-        // BT gone: the Oboe unbinds (routedBtKey null) and the sink leaves the device list.
+        // BT gone: the route leaves BT (back to the phone speaker) and the sink leaves the list.
         f.onPhoneRoute()
         c.onRouteChanged()
         advanceTimeBy(3_500) // past CAR_LOCK_CLEAR_DEBOUNCE_MS
@@ -326,10 +321,10 @@ class SendspinVolumeCoordinatorTest {
         f.carDevicesFlow.emit(setOf(CAR_KEY))
         advanceUntilIdle()
 
-        f.routedBtKey = null        // transient loss: Oboe unbound (device still "connected")
+        f.routeType = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER // transient: route briefly off BT
         c.onRouteChanged()          // schedules the settle exit
         advanceTimeBy(1_000)        // mid-settle
-        f.routedBtKey = "bt:MINI45864" // flap re-binds to the car
+        f.onBtRoute()               // flap re-binds to the car (routeType BT + car connected)
         c.onRouteChanged()          // routed to car again -> cancels the pending exit
         advanceTimeBy(3_500)
         advanceUntilIdle()
@@ -340,10 +335,32 @@ class SendspinVolumeCoordinatorTest {
     }
 
     @Test
-    fun carDisconnect_deviceStillListedButOboeUnbound_restores() = runTest(UnconfinedTestDispatcher()) {
-        // Real disconnect: Android keeps the A2DP device in getDevices for a while, but the Oboe
-        // routed device unbinds immediately. The exit uses the routed-only truth, so the lingering
-        // "connected" device must NOT fool the settle re-check into aborting the restore.
+    fun carActive_routedTypeStillBtButNameUnresolved_doesNotExit() = runTest(UnconfinedTestDispatcher()) {
+        // Regression (cold-start-already-in-car): the Oboe product name resolves to null/"unknown"
+        // for seconds even while genuinely routed to the car, so a name-based exit check falsely
+        // reported "gone" and tore down the live session. The exit gates on the routed TYPE (still
+        // BT) + car connected, so an unresolved name must NOT trigger a restore.
+        val f = Fixture().apply { onBtRoute() }
+        val c = f.build()
+        c.start(backgroundScope)
+        advanceUntilIdle()
+        f.carDevicesFlow.emit(setOf(CAR_KEY)) // entered + pinned
+        advanceUntilIdle()
+
+        f.btRouteKey = null // product name unresolved upstream (would be bt:unknown); type stays BT
+        c.onRouteChanged()
+        advanceTimeBy(3_500)
+        advanceUntilIdle()
+
+        f.assertNoWriteOf(idx(80))
+        verify(exactly = 0) { f.playerRepository.setSelectionLock(null) }
+    }
+
+    @Test
+    fun carDisconnect_routedTypeLeftBtButDeviceStillListed_restores() = runTest(UnconfinedTestDispatcher()) {
+        // Real disconnect: the routed TYPE leaves BT immediately (stream rebinds to builtin), but
+        // Android keeps the A2DP device in getDevices for a while. The type gate fails first, so the
+        // lingering "connected" device does NOT abort the restore.
         val f = Fixture().apply { onBtRoute() }
         val c = f.build()
         c.start(backgroundScope)
@@ -351,7 +368,7 @@ class SendspinVolumeCoordinatorTest {
         f.carDevicesFlow.emit(setOf(CAR_KEY))
         advanceUntilIdle()
 
-        f.routedBtKey = null // Oboe unbound; devices still lists MINI45864 (Android lag)
+        f.routeType = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER // routed off BT; devices still lists car
         c.onRouteChanged()
         advanceTimeBy(3_500)
         advanceUntilIdle()
@@ -362,8 +379,8 @@ class SendspinVolumeCoordinatorTest {
 
     @Test
     fun carDisconnect_flapReBindsByExpiry_settleRecheckAborts() = runTest(UnconfinedTestDispatcher()) {
-        // Even with NO reconnect poke, the settle re-check must abort the exit when the Oboe has
-        // re-bound to the car by expiry (the native-reopen flap that fires no route event).
+        // Even with NO reconnect poke, the settle re-check must abort the exit when the route has
+        // re-settled on BT (car connected) by expiry (a native-reopen flap that fires no route event).
         val f = Fixture().apply { onBtRoute() }
         val c = f.build()
         c.start(backgroundScope)
@@ -371,10 +388,10 @@ class SendspinVolumeCoordinatorTest {
         f.carDevicesFlow.emit(setOf(CAR_KEY))
         advanceUntilIdle()
 
-        f.routedBtKey = null   // transient unbind -> schedule exit
+        f.routeType = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER // transient off BT -> schedule exit
         c.onRouteChanged()
         advanceTimeBy(1_000)
-        f.routedBtKey = "bt:MINI45864" // re-bound, but NO onRouteChanged poke this time
+        f.onBtRoute()          // re-settled on the car, but NO onRouteChanged poke this time
         advanceTimeBy(3_500)   // settle fires -> re-check sees car routed -> abort
         advanceUntilIdle()
 

--- a/core/src/test/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackInjectCountTest.kt
+++ b/core/src/test/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackInjectCountTest.kt
@@ -14,15 +14,15 @@ class SeedTrackInjectCountTest {
 
     @Test
     fun `zero discovery reserves up to the max fraction`() {
-        // (1 - 0) * 0.4 * 40 = 16
-        assertThat(seedTrackInjectCount(discovery = 0.0, target = 40)).isEqualTo(16)
+        // (1 - 0) * 0.30 * 40 = 12
+        assertThat(seedTrackInjectCount(discovery = 0.0, target = 40)).isEqualTo(12)
     }
 
     @Test
     fun `mid discovery reserves a proportional slice`() {
-        // (1 - 0.5) * 0.4 * 40 = 8
-        assertThat(seedTrackInjectCount(discovery = 0.5, target = 40)).isEqualTo(8)
-        // (1 - 0.875) * 0.4 * 40 = 2 (the value observed in the 5-run test)
+        // (1 - 0.5) * 0.30 * 40 = 6
+        assertThat(seedTrackInjectCount(discovery = 0.5, target = 40)).isEqualTo(6)
+        // (1 - 0.875) * 0.30 * 40 = 1.5 -> 2
         assertThat(seedTrackInjectCount(discovery = 0.875, target = 40)).isEqualTo(2)
     }
 


### PR DESCRIPTION
## Summary

This branch carries the car-audio route-unify work plus four independent fixes found and verified this session (on-device, Samsung SM-S938B). Each fix is its own commit.

## Changes

### Car audio (pre-existing on this branch)
- Unify route state to a single source of truth, gate the exit on the routed device type (not the exact product name), and keep the 100% pin through a connect-time Bluetooth flap.

### Follow Me
- Fix service self-stop on a background (START_STICKY) restart: the config collector acted on the StateFlow default (`enabled=false`) before `load()` populated it and called `stopSelf()`, so Follow Me never came back. Now the collector is gated on `load()`.
- Stay enabled across a Bluetooth off/flap: Bluetooth is now a runtime gate (scanning pauses while BT is off, resumes when it returns) instead of a one-way persisted disable that silently turned Follow Me off for good after a single flap.

### Smart Mix
- Reduce off-taste / filler tracks: the loved-inject score floor now derives from the Strictness slider (was a hardcoded 0.1), the own-track fraction cap is lowered from 0.4 to 0.30, the in-genre gate for injected tracks is now family-aware, and cross-run genre rotation is Variety-gated (stays in the current genre neighborhood at low Variety instead of whiplashing to unrelated genres).

### Sendspin (battery)
- Release audio resources (native Oboe output, wake lock, WiFi low-latency lock) when the phone stops being the active output. Previously they were held indefinitely (1h+ observed) while the phone Sendspin player was idle server-side, causing significant battery drain. Locks now follow actual output activity: released after a short idle grace and on a full stream-end teardown (15s), re-acquired on resume. The client stays connected as an available player.

## Validation
- detekt + unit tests green, debug APK built and installed.
- On-device verification per fix via `dumpsys power`/`dumpsys wifi` and the MA REST queue state: Follow Me survives BT off/on, Smart Mix cluster stays coherent, and Sendspin releases all locks + closes the Oboe output within the grace after deselect, with no regression on track changes, re-select, or pause/resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
