### PR TITLE
Revert Sendspin audio-focus-on-idle (broke notification duck restore)

### DIFF
--- a/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
@@ -503,11 +503,14 @@ class SendspinAudioController(
                 recomputeAvailability()
                 Log.d(TAG, "Sendspin state: $state, isStreaming=$isStreaming, isReady=$isReady, sync=$localSyncState")
 
-                // Wake + Wi-Fi locks AND audio focus now follow the manager's
-                // audioResourcesActive flow (collector below), not this transport
-                // edge, so they release once the phone stops being an actual output
-                // even though the client stays connected (STREAMING) as an
-                // available player.
+                // Audio focus still tracks the STREAMING transport edge. The wake
+                // + Wi-Fi locks are NOT acquired here anymore: they follow the
+                // manager's audioResourcesActive flow (collector below), so they
+                // release once the phone stops being an actual output even though
+                // the client stays connected (STREAMING) as an available player.
+                if (!wasStreaming && transportState == SendspinState.STREAMING) {
+                    if (!hasAudioFocus) requestAudioFocus()
+                }
                 if (wasStreaming && transportState != SendspinState.STREAMING) {
                     Log.d(TAG, "Sendspin dropped while streaming")
                 }
@@ -534,18 +537,9 @@ class SendspinAudioController(
         // player. distinctUntilChanged so we only act on real edges.
         collectorJobs += scope.launch {
             // StateFlow is already conflated (distinct-by-equality), so collect
-            // sees only real true/false edges. Audio focus rides the same signal:
-            // requested while we are an actual output, abandoned on idle/deselect
-            // so other apps regain focus (voluntary abandon fires no LOSS callback,
-            // so it never triggers our own focus-loss pause path).
+            // sees only real true/false edges.
             sendspinManager.audioResourcesActive.collect { active ->
-                if (active) {
-                    acquireLocks()
-                    if (!hasAudioFocus) requestAudioFocus()
-                } else {
-                    releaseLocks()
-                    abandonAudioFocus()
-                }
+                if (active) acquireLocks() else releaseLocks()
             }
         }
 


### PR DESCRIPTION
The audio-focus-on-idle commit (3fd8041) abandoned the focus request when audioResourcesActive went false. If the engine idle-stopped around a notification, the follow-up AUDIOFOCUS_GAIN was never delivered, so restoreVolume() never ran and Sendspin stayed at the duck gain (0.1) - very noticeable in the car where STREAM_MUSIC is pinned to 100% (the quiet is pure engine-gain, the pin is untouched).

Reverts to the prior behaviour: audio focus rides the STREAMING transport edge and is never abandoned on idle, so GAIN always arrives and the duck restores. The battery fix (locks + Oboe idle-teardown) is unaffected - it does not depend on the focus change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)