### PR TITLE
Car audio: don't drop volume on an Oboe reopen (null routed type != disconnect)

### DIFF
--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinator.kt
@@ -300,8 +300,16 @@ class SendspinVolumeCoordinator(
      * ~8s post-disconnect lag can never abort a real restore - by then the type has already left BT).
      */
     private fun routedCarActive(): Boolean {
-        val type = currentOutputDeviceType() ?: return false
-        if (!isBluetoothSink(type)) return false
+        // A NULL routed type means the Oboe stream is mid-reopen (routedDeviceType is
+        // reset to -1 in releaseInternal until the AudioDeviceCallback re-resolves),
+        // NOT a disconnect. A real disconnect resolves to a CONCRETE non-BT (builtin)
+        // type. Treating null as "gone" spuriously exited a live car session across a
+        // reopen (duck/resume, route change, underrun rebind) and restored the stale
+        // pre-car volume while the car was still connected. So bail only on a concrete
+        // non-BT type; null (unresolved) or a BT type falls through to the connected-
+        // car-sink truth, mirroring how resolveCarKey handles a null routed key on entry.
+        val type = currentOutputDeviceType()
+        if (type != null && !isBluetoothSink(type)) return false
         return audioManager.connectedBtSinkKeys().any { it in carAudioDevices }
     }
 

--- a/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
+++ b/core/src/test/java/net/asksakis/massdroidv2/data/sendspin/SendspinVolumeCoordinatorTest.kt
@@ -335,6 +335,29 @@ class SendspinVolumeCoordinatorTest {
     }
 
     @Test
+    fun carActive_routedTypeNullDuringReopen_doesNotExit() = runTest(UnconfinedTestDispatcher()) {
+        // Regression: an Oboe reopen (duck/resume, route change, underrun rebind) resets
+        // routedDeviceType to -1, so currentOutputDeviceType() returns null transiently.
+        // A null type is "resolving", NOT a disconnect (that resolves to a concrete
+        // builtin type), so the live car session must hold and the pre-car volume must
+        // NOT be restored while the car BT sink is still connected.
+        val f = Fixture().apply { onBtRoute() }
+        val c = f.build()
+        c.start(backgroundScope)
+        advanceUntilIdle()
+        f.carDevicesFlow.emit(setOf(CAR_KEY)) // car session active, pre-car (80) captured
+        advanceUntilIdle()
+
+        f.routeType = null            // mid-reopen: routed type unresolved; car sink stays connected
+        c.onRouteChanged()
+        advanceTimeBy(3_500)          // past CAR_LOCK_CLEAR_DEBOUNCE_MS
+        advanceUntilIdle()
+
+        f.assertNoWriteOf(idx(80))
+        verify(exactly = 0) { f.playerRepository.setSelectionLock(null) }
+    }
+
+    @Test
     fun carActive_routedTypeStillBtButNameUnresolved_doesNotExit() = runTest(UnconfinedTestDispatcher()) {
         // Regression (cold-start-already-in-car): the Oboe product name resolves to null/"unknown"
         // for seconds even while genuinely routed to the car, so a name-based exit check falsely


### PR DESCRIPTION
In the car (BT A2DP), a notification/duck triggers an Oboe stream reopen, which resets the engine's routedDeviceType to -1 until the AudioDeviceCallback re-resolves it. getRoutedDeviceType() then returns null, and routedCarActive() treated null as 'left the car' (`?: return false`), scheduling the car-session exit; if the stream was still reopening at the 3s debounce, the exit fired and restored the pre-car volume (e.g. 40%) even though the car never disconnected. The user had to re-raise it with the volume rocker.

Fix: a null routed type is 'resolving', not a disconnect (a real disconnect resolves to a concrete builtin type). routedCarActive() now bails only on a concrete non-BT type; null or a BT type falls through to the connected-car-sink truth, mirroring how resolveCarKey handles a null routed key on entry (the entry/exit asymmetry was the bug). Confirmed against the 13:55 field log (car-audio active->gone in 3s with no BT disconnect). +1 regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)