### PR TITLE
Smart Mix: regression test for the Variety-gated genre movement

### DIFF
--- a/core/src/main/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackMixGenerator.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackMixGenerator.kt
@@ -191,6 +191,29 @@ internal fun genreGatePasses(
 }
 
 /**
+ * Variety-gated genre movement between consecutive mixes. Given a candidate
+ * primary seed's genre families and the families of the recent mixes, decides
+ * whether the candidate is PREFERRED for the next cluster:
+ *  - below [FAMILY_HOP_VARIETY_THRESHOLD]: prefer the SAME family as recent
+ *    (coherent adjacency drift, no whiplash to unrelated genres),
+ *  - at/above it: prefer a DIFFERENT family (exploration hop).
+ * With no recent families there is no preference (returns false), so the caller
+ * falls back to the plain fresh pool. This keeps Smart Mix in the current genre
+ * neighbourhood at mid/low Variety instead of jumping deep house -> hard rock
+ * every run (the whiplash the old always-on family-hop caused).
+ */
+@VisibleForTesting
+internal fun prefersCandidateFamily(
+    candidateFamilies: Set<String>,
+    recentFamilies: Set<String>,
+    variety: Double,
+): Boolean {
+    if (recentFamilies.isEmpty()) return false
+    val sharesRecentFamily = candidateFamilies.any { it in recentFamilies }
+    return if (variety >= FAMILY_HOP_VARIETY_THRESHOLD) !sharesRecentFamily else sharesRecentFamily
+}
+
+/**
  * Track-level recommendation generator: recent (or in-genre) well-listened
  * tracks seed Last.fm `track.getSimilar`, producing a coherent candidate pool
  * that is resolved to playable provider URIs (cache-first + bounded search +
@@ -516,12 +539,8 @@ class SeedTrackMixGenerator @Inject constructor(
         val exactFresh = primaryPool.filter { seed ->
             coherenceGenres(seed).none { it in recency.recentClusterGenres }
         }
-        val preferred = when {
-            recentFamilies.isEmpty() -> emptyList()
-            tuning.variety >= FAMILY_HOP_VARIETY_THRESHOLD ->
-                exactFresh.filter { seed -> genreFamilies(coherenceGenres(seed)).none { it in recentFamilies } }
-            else ->
-                exactFresh.filter { seed -> genreFamilies(coherenceGenres(seed)).any { it in recentFamilies } }
+        val preferred = exactFresh.filter { seed ->
+            prefersCandidateFamily(genreFamilies(coherenceGenres(seed)), recentFamilies, tuning.variety)
         }
         val freshPool = preferred.ifEmpty { exactFresh }
         val primary = freshPool.ifEmpty { primaryPool }.shuffled(random).first()

--- a/core/src/test/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackInjectCountTest.kt
+++ b/core/src/test/java/net/asksakis/massdroidv2/domain/recommendation/SeedTrackInjectCountTest.kt
@@ -85,4 +85,40 @@ class SeedTrackInjectCountTest {
         val high = strictnessRankedPool(recencyPool, 1.0).map { it.trackUri }
         assertThat(low).isNotEqualTo(high)
     }
+
+    // --- prefersCandidateFamily: Variety-gated genre movement (no whiplash) ---
+    // Pins the cluster-whiplash fix: at low/mid Variety the next mix stays in the
+    // recent genre family; only high Variety hops to a different family.
+
+    private val recentElectronic = setOf("electronic")
+
+    @Test
+    fun `low variety prefers staying in the recent family`() {
+        // deep house session (electronic family), low variety -> prefer electronic, reject rock.
+        assertThat(prefersCandidateFamily(setOf("electronic"), recentElectronic, variety = 0.3)).isTrue()
+        assertThat(prefersCandidateFamily(setOf("rock"), recentElectronic, variety = 0.3)).isFalse()
+    }
+
+    @Test
+    fun `high variety prefers hopping to a different family`() {
+        // high variety -> exploration: reject the recent family, prefer a foreign one.
+        assertThat(prefersCandidateFamily(setOf("electronic"), recentElectronic, variety = 0.9)).isFalse()
+        assertThat(prefersCandidateFamily(setOf("rock"), recentElectronic, variety = 0.9)).isTrue()
+    }
+
+    @Test
+    fun `no recent families means no preference`() {
+        // First run / cleared history: nothing preferred, caller falls back to the fresh pool.
+        assertThat(prefersCandidateFamily(setOf("electronic"), emptySet(), variety = 0.3)).isFalse()
+        assertThat(prefersCandidateFamily(setOf("rock"), emptySet(), variety = 0.9)).isFalse()
+    }
+
+    @Test
+    fun `the stay-hop flip happens across the threshold, not below it`() {
+        // Same candidate (recent family), only Variety changes: mid stays, high hops.
+        val staysMid = prefersCandidateFamily(setOf("electronic"), recentElectronic, variety = 0.5)
+        val staysHigh = prefersCandidateFamily(setOf("electronic"), recentElectronic, variety = 0.8)
+        assertThat(staysMid).isTrue()   // below threshold: keep same family
+        assertThat(staysHigh).isFalse() // above threshold: hop away
+    }
 }


### PR DESCRIPTION
Pins the cluster-whiplash fix so future changes can't silently reintroduce it. Extracts the per-candidate decision into a pure @VisibleForTesting prefersCandidateFamily(candidateFamilies, recentFamilies, variety) (behaviour-preserving; selectSeeds now calls it) and adds tests: low/mid Variety stays in the recent genre family, only high Variety hops to a different family, and no recent families means no preference.

Scope note: the car-reopen volume drop already has carActive_routedTypeNullDuringReopen_doesNotExit; the Follow Me BT runtime gate and the Sendspin idle-teardown are Android-service / coroutine-manager level and not cleanly unit-testable without a refactor, so no fragile tests were forced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)