### PR TITLE
Battery optimization: remove the launch nag, make it an optional Settings toggle

### DIFF
--- a/app/src/main/java/net/asksakis/massdroidv2/ui/MainActivity.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/MainActivity.kt
@@ -10,14 +10,11 @@ import net.asksakis.massdroidv2.ui.components.MdSwitch
 import net.asksakis.massdroidv2.ui.components.MdTextButton
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.PowerManager
 import android.provider.Settings
 import android.media.AudioManager
 import android.view.KeyEvent
@@ -166,11 +163,11 @@ class MainActivity : ComponentActivity() {
         }
         // The activity may be (re)launched via the OAuth callback deep link.
         handleOAuthCallback(intent)
-        // No battery-optimization prompt on a car head unit (always powered, and the
-        // dialog is an unwanted distraction). The exemption permission is stripped too.
-        if (!net.asksakis.massdroidv2.BuildConfig.IS_AUTOMOTIVE) {
-            checkBatteryOptimization()
-        }
+        // Battery-optimization exemption is NOT prompted at launch anymore: it is
+        // not needed for reliable playback (the Sendspin foreground service is
+        // doze-exempt while active) nor for Follow Me (motion-gated; a room change
+        // is motion, which takes the device out of doze so scanning runs). It is now
+        // an optional, no-nag toggle under Settings > Diagnostics for power users.
         handleShortcutIntent(intent)
 
         // Cache sendspin client ID for the local-player checks below. STREAM_MUSIC
@@ -410,30 +407,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun checkBatteryOptimization() {
-        val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
-        if (!powerManager.isIgnoringBatteryOptimizations(packageName)) {
-            showBatteryOptimizationDialog()
-        }
-    }
-
-    @SuppressLint("BatteryLife")
-    private fun showBatteryOptimizationDialog() {
-        android.app.AlertDialog.Builder(this)
-            .setTitle("Disable Battery Optimization")
-            .setMessage(
-                "For reliable background music playback, MassDroid needs to be " +
-                "excluded from battery optimization.\n\n" +
-                "Without this, Android may stop playback when the screen is off."
-            )
-            .setPositiveButton("Disable Optimization") { _, _ ->
-                val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-                intent.data = Uri.parse("package:$packageName")
-                startActivity(intent)
-            }
-            .setNegativeButton("Skip", null)
-            .show()
-    }
 }
 
 /**

--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/settings/SettingsScreen.kt
@@ -537,6 +537,51 @@ private fun DiagnosticsCard() {
             ) {
                 Text("Share logs")
             }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+            Text("Battery optimization", style = MaterialTheme.typography.titleMedium)
+            val powerManager = remember {
+                context.getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
+            }
+            var batteryExcluded by remember {
+                mutableStateOf(powerManager.isIgnoringBatteryOptimizations(context.packageName))
+            }
+            // Re-read on resume: the user grants it in the system screen and returns here.
+            val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+            androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+                val obs = androidx.lifecycle.LifecycleEventObserver { _, event ->
+                    if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                        batteryExcluded = powerManager.isIgnoringBatteryOptimizations(context.packageName)
+                    }
+                }
+                lifecycleOwner.lifecycle.addObserver(obs)
+                onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+            }
+            Text(
+                "Optional. Playback keeps running with the screen off (the audio service is doze-exempt " +
+                    "while active) and room detection works too (moving between rooms wakes the device out " +
+                    "of doze). Excluding MassDroid only helps background reconnects during long deep-doze. " +
+                    "Currently: " + if (batteryExcluded) "excluded." else "not excluded.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (!batteryExcluded) {
+                MdFilledTonalButton(
+                    onClick = {
+                        runCatching {
+                            context.startActivity(
+                                android.content.Intent(
+                                    android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                                    android.net.Uri.parse("package:${context.packageName}")
+                                )
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Exclude from battery optimization")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The launch-time 'Disable Battery Optimization' dialog re-appeared on every start (no persistence) and its message was misleading. Investigation showed the exemption is not actually needed: playback runs on a doze-exempt foreground service, and Follow Me is motion-gated (a room change is motion, which takes the device out of doze so isDeviceIdleMode is false and scanning runs). Only marginal background-reconnect reliability during long deep-doze benefits.

So: removed checkBatteryOptimization()/the dialog from MainActivity (no more nag), and added an optional, honest toggle under Settings > Diagnostics that shows the current state and launches the system exemption request for power users who still want it. Copy no longer claims 'Android may stop playback'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)