### PR TITLE
Release the duck when the interrupting sound stops, not on a timer

### DIFF
--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinManager.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinManager.kt
@@ -577,8 +577,8 @@ class SendspinManager(
         // Transient focus-loss attenuation on OUR OWN native output gain (not the
         // shared STREAM_MUSIC), so a nav prompt / notification from another app
         // ducks only MassDroid's music and never that app's audio. 0.5 (-6dB) was
-        // too shallow to notice under a loud prompt; DUCK_GAIN (~-14dB) matches
-        // the platform's own auto-duck depth. currentVolume is left unchanged so
+        // too shallow to notice under a loud prompt; DUCK_GAIN (-20dB) is deeper
+        // than the platform's own auto-duck. currentVolume is left unchanged so
         // restoreVolume() brings us back to full gain on AUDIOFOCUS_GAIN.
         // WHEN the gain comes back is not decided here. The release is driven by
         // the interrupting sound actually stopping, which is audio-focus policy

--- a/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinManager.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/data/sendspin/SendspinManager.kt
@@ -45,16 +45,6 @@ class SendspinManager(
         // The transition is not abrupt because the native ramp fades to it over
         // VOLUME_FADE_SEC (~150ms), not the snappy mute fade.
         private const val DUCK_GAIN = 0.1f
-        // Safety net: if AUDIOFOCUS_GAIN is never delivered after a duck (dropped
-        // focus request, flaky car HMI, an interrupter that never abandons focus),
-        // auto-restore the gain so we can never stay stuck ducked - especially in
-        // the car where STREAM_MUSIC is pinned 100% and the quiet would otherwise
-        // persist. Normal transient interruptions return a GAIN within ~1-4s; the
-        // old 45s value left music audibly quiet for up to 45s when the GAIN was
-        // dropped (a notification/SpeedCam alert in the car). Kept short: ducking
-        // means we keep PLAYING (not paused), so restoring a little early over the
-        // tail of a lingering prompt is fine, whereas a long silence is not.
-        private const val DUCK_SAFETY_RESTORE_MS = 10_000L
         private const val HEARTBEAT_INTERVAL_MS = 2000L
         // After stream/end, wait this long before fully releasing the audio
         // resources (Oboe output, wake + Wi-Fi locks). A normal track change is
@@ -101,7 +91,6 @@ class SendspinManager(
     private val lifecycleMutex = Mutex()
     @Volatile private var streamEpoch = 0L
     private var idleTeardownJob: Job? = null
-    private var duckRestoreJob: Job? = null
 
     // Maps the active engine's output-active transitions to [_audioResourcesActive]
     // so the controller holds wake + Wi-Fi locks only while audio actually flows:
@@ -591,20 +580,16 @@ class SendspinManager(
         // too shallow to notice under a loud prompt; DUCK_GAIN (~-14dB) matches
         // the platform's own auto-duck depth. currentVolume is left unchanged so
         // restoreVolume() brings us back to full gain on AUDIOFOCUS_GAIN.
+        // WHEN the gain comes back is not decided here. The release is driven by
+        // the interrupting sound actually stopping, which is audio-focus policy
+        // and lives with the focus listener in
+        // SendspinAudioController.duckUntilInterrupterEnds; this used to be a
+        // flat timer here and it restored full volume over a ringing alarm.
         if (!muted) audio.setVolume(DUCK_GAIN)
         Log.i(TAG, "Duck -> $DUCK_GAIN gain")
-        // Safety net against a lost AUDIOFOCUS_GAIN leaving us stuck ducked.
-        duckRestoreJob?.cancel()
-        duckRestoreJob = scope.launch {
-            delay(DUCK_SAFETY_RESTORE_MS)
-            Log.w(TAG, "Duck safety timeout (${DUCK_SAFETY_RESTORE_MS}ms): no AUDIOFOCUS_GAIN, restoring gain")
-            if (!muted) audio.setVolume(1f)
-        }
     }
 
     fun restoreVolume() {
-        duckRestoreJob?.cancel()
-        duckRestoreJob = null
         if (!muted) audio.setVolume(1f)
     }
 
@@ -869,8 +854,6 @@ class SendspinManager(
         // teardown no-op under the mutex; releaseInternal is idempotent anyway).
         idleTeardownJob?.cancel()
         idleTeardownJob = null
-        duckRestoreJob?.cancel()
-        duckRestoreJob = null
         streamEpoch++
         _audioResourcesActive.value = false
         hasActiveProtocolStream = false

--- a/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
@@ -97,10 +97,15 @@ class SendspinAudioController(
         // returned a GAIN), so the gain is restored on this deadline exactly as
         // the old blind timer did.
         private const val DUCK_INTERRUPTER_WAIT_MS = 10_000L
-        // Safety cap once the interrupter IS visible. Reached only if its player
-        // never leaves the configuration list, so it is generous: a real alarm or
-        // a long voice message is a legitimate reason to stay quiet.
-        private const val DUCK_MAX_MS = 5 * 60_000L
+        // Safety cap once the interrupter IS visible. The wait is for ANY
+        // interrupter usage to clear, not the one we ducked for, so a player some
+        // other app leaves registered (navigation guidance during a whole trip is
+        // the obvious candidate) can hold the duck open. Combine that with an
+        // interrupter that never returns a GAIN and the cap is what we are left
+        // with, in a car where STREAM_MUSIC is pinned at 100%: keep it near the
+        // ten seconds the old blind timer recovered in rather than minutes. A real
+        // alarm ringing longer than this justifies the quiet anyway.
+        private const val DUCK_MAX_MS = 60_000L
         // Usages that mean "another app is deliberately talking over us". Our own
         // output is USAGE_MEDIA, so it can never match.
         private val INTERRUPTER_USAGES = setOf(
@@ -1210,6 +1215,12 @@ class SendspinAudioController(
                     AudioManager.AUDIOFOCUS_LOSS -> {
                         Log.i(TAG, "Audio focus lost permanently")
                         hasAudioFocus = false
+                        // Nothing is ducking any more. A watch left running can
+                        // only ever restore full gain, so this is tidiness rather
+                        // than safety, but it stops a "no interrupting sound
+                        // visible" warning firing minutes later with no duck.
+                        duckWatchJob?.cancel()
+                        duckWatchJob = null
                         unfreezeOutput("focus")
                         // Align intent with the permanent loss: another app
                         // has taken over, the user is no longer "trying to
@@ -1238,6 +1249,10 @@ class SendspinAudioController(
                                 // skips forward to the live group position under the
                                 // mute. See unfreezeOutput.
                                 Log.i(TAG, "Audio focus lost transiently (active call): freezing")
+                                // The freeze supersedes any duck; see the
+                                // AUDIOFOCUS_LOSS branch for why this is tidiness.
+                                duckWatchJob?.cancel()
+                                duckWatchJob = null
                                 freezeOutput("focus")
                             } else {
                                 // SHORT non-call interruption (notification ping,
@@ -1282,16 +1297,21 @@ class SendspinAudioController(
      * has to appear, within [DUCK_INTERRUPTER_WAIT_MS]; if it never does we
      * cannot observe it and restore on that deadline, which preserves the
      * original fix for an interrupter that takes focus and never gives it back.
-     * Then we wait for it to go away, capped by [DUCK_MAX_MS]. A GAIN arriving at
-     * any point cancels this and restores immediately.
+     * Then we wait for it to go away, capped by [DUCK_MAX_MS]. That second wait
+     * is for ANY interrupter usage to clear, not the one we ducked for, which is
+     * why the cap is kept short rather than generous. A GAIN arriving at any
+     * point cancels this and restores immediately.
      *
      * Both phases collect a freshly seeded flow, so the transition between them
      * cannot be missed: a registration reports the current state before waiting
      * for a change.
      */
     private fun duckUntilInterrupterEnds() {
-        sendspinManager.duck()
+        // Cancel BEFORE ducking: the other order leaves a window in which the
+        // previous watch restores full gain right after this duck applied it, and
+        // then nothing lowers it again for the rest of the interruption.
         duckWatchJob?.cancel()
+        sendspinManager.duck()
         duckWatchJob = scope.launch {
             val appeared = withTimeoutOrNull(DUCK_INTERRUPTER_WAIT_MS) {
                 interrupterActive().first { it }

--- a/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
+++ b/core/src/main/java/net/asksakis/massdroidv2/playback/SendspinAudioController.kt
@@ -23,8 +23,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -87,6 +90,29 @@ class SendspinAudioController(
         // ordering is there to prevent, and because a missing answer means the
         // connection is broken again, in which case the refresh fails too.
         private const val PAUSE_REASSERT_TIMEOUT_MS = 5_000L
+        // How long a duck waits for the interrupting sound to actually show up in
+        // the platform's playback configurations. Nothing there means we cannot
+        // see the interrupter (it may be playing as plain media, or it took focus
+        // without playing at all, which is the SpeedCam Droid case that never
+        // returned a GAIN), so the gain is restored on this deadline exactly as
+        // the old blind timer did.
+        private const val DUCK_INTERRUPTER_WAIT_MS = 10_000L
+        // Safety cap once the interrupter IS visible. Reached only if its player
+        // never leaves the configuration list, so it is generous: a real alarm or
+        // a long voice message is a legitimate reason to stay quiet.
+        private const val DUCK_MAX_MS = 5 * 60_000L
+        // Usages that mean "another app is deliberately talking over us". Our own
+        // output is USAGE_MEDIA, so it can never match.
+        private val INTERRUPTER_USAGES = setOf(
+            AudioAttributes.USAGE_ALARM,
+            AudioAttributes.USAGE_NOTIFICATION,
+            AudioAttributes.USAGE_NOTIFICATION_RINGTONE,
+            AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY,
+            AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE,
+            AudioAttributes.USAGE_ASSISTANCE_SONIFICATION,
+            AudioAttributes.USAGE_ASSISTANT,
+            AudioAttributes.USAGE_VOICE_COMMUNICATION,
+        )
     }
 
     private val exceptionHandler = CoroutineExceptionHandler { _, e ->
@@ -307,6 +333,13 @@ class SendspinAudioController(
             }
         }
     }
+
+    // In-flight reconnect reconciliation, kept so a later reconnect supersedes it.
+    private var reconnectReassertJob: Job? = null
+
+    // Watches an active duck so the gain is restored when the interrupting sound
+    // ends, rather than on a fixed timer. See [duckUntilInterrupterEnds].
+    private var duckWatchJob: Job? = null
 
     // Locks
     private var wakeLock: PowerManager.WakeLock? = null
@@ -846,7 +879,16 @@ class SendspinAudioController(
                             "(wantToResume=$wantToResume, userIntent=$intent, " +
                             "sendspinIsSelected=$sendspinIsSelected)"
                     )
-                    launch { resumeOrReassertPause(wantToResume, intent, sendspinIsSelected) }
+                    // Supersede an in-flight run. Moving `refresh()` off the
+                    // collector means a second reconnect within the ack wait
+                    // could otherwise refresh the Sendspin transport while the
+                    // first run's pause was still unconfirmed, which is exactly
+                    // the ordering this is here to guarantee. Cancelling only
+                    // abandons the WAIT: that pause has already been written to
+                    // the socket, and this run sends its own.
+                    reconnectReassertJob?.cancel()
+                    reconnectReassertJob =
+                        launch { resumeOrReassertPause(wantToResume, intent, sendspinIsSelected) }
                 }
                 if (isConnected) connectedBefore = true
             }
@@ -934,6 +976,13 @@ class SendspinAudioController(
         collectorJobs.clear()
         autoRecoveryJob?.cancel()
         autoRecoveryJob = null
+        // A duck left in place would be a silent player on the next start, and
+        // nothing else restores the gain once this watch is gone.
+        reconnectReassertJob?.cancel()
+        reconnectReassertJob = null
+        duckWatchJob?.cancel()
+        duckWatchJob = null
+        sendspinManager.restoreVolume()
         reconnectJob?.cancel()
         reconnectJob = null
         abandonAudioFocus()
@@ -1119,6 +1168,8 @@ class SendspinAudioController(
                             Log.i(TAG, "Focus gained during active call (mode=${audioManager.mode}); staying paused until the call ends")
                             return@setOnAudioFocusChangeListener
                         }
+                        duckWatchJob?.cancel()
+                        duckWatchJob = null
                         sendspinManager.restoreVolume()
                         // If the transient loss FROZE the solo output (buffer
                         // preserved), just unfreeze: playback resumes instantly
@@ -1198,18 +1249,90 @@ class SendspinAudioController(
                                 // keeps the stream alive and routed; restoreVolume()
                                 // on GAIN brings the level back.
                                 Log.i(TAG, "Audio focus lost transiently (no call): ducking")
-                                sendspinManager.duck()
+                                duckUntilInterrupterEnds()
                             }
                         }
                     }
                     AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
                         Log.i(TAG, "Audio focus: ducking (pre-duck vol=${sendspinManager.currentVolume})")
-                        sendspinManager.duck()
+                        duckUntilInterrupterEnds()
                     }
                 }
             }
             .build()
     }
+
+    /**
+     * Duck, and restore the gain when the interrupting sound actually stops.
+     *
+     * The release used to be a flat ten-second timer whose premise was "no
+     * AUDIOFOCUS_GAIN by now means the GAIN was dropped". That is wrong for any
+     * interruption longer than the timer: measured against a real alarm on two
+     * phones, the GAIN arrived after 14.8 s, 16.4 s, 12.8 s and 19.6 s, so the
+     * timer restored full volume over a still-ringing alarm every time. The
+     * events were never missing, we were second-guessing them.
+     *
+     * The platform does report when another app's sound starts and stops, through
+     * [AudioManager.AudioPlaybackCallback]. An app without MODIFY_AUDIO_ROUTING
+     * still sees the usage of other apps' players (AOSP's
+     * `AudioPlaybackConfiguration.anonymizedCopy` keeps usage, content type and
+     * flags, and strips only the identifiers), which is all this needs.
+     *
+     * So the wait has two phases, each with its own bound. First the interrupter
+     * has to appear, within [DUCK_INTERRUPTER_WAIT_MS]; if it never does we
+     * cannot observe it and restore on that deadline, which preserves the
+     * original fix for an interrupter that takes focus and never gives it back.
+     * Then we wait for it to go away, capped by [DUCK_MAX_MS]. A GAIN arriving at
+     * any point cancels this and restores immediately.
+     *
+     * Both phases collect a freshly seeded flow, so the transition between them
+     * cannot be missed: a registration reports the current state before waiting
+     * for a change.
+     */
+    private fun duckUntilInterrupterEnds() {
+        sendspinManager.duck()
+        duckWatchJob?.cancel()
+        duckWatchJob = scope.launch {
+            val appeared = withTimeoutOrNull(DUCK_INTERRUPTER_WAIT_MS) {
+                interrupterActive().first { it }
+            }
+            if (appeared == null) {
+                Log.w(TAG, "Duck: no interrupting sound visible within ${DUCK_INTERRUPTER_WAIT_MS}ms, restoring gain")
+                sendspinManager.restoreVolume()
+                return@launch
+            }
+            val ended = withTimeoutOrNull(DUCK_MAX_MS) {
+                interrupterActive().first { !it }
+            }
+            if (ended == null) {
+                Log.w(TAG, "Duck: interrupting sound still playing after ${DUCK_MAX_MS}ms, restoring gain")
+            } else {
+                Log.i(TAG, "Duck: interrupting sound ended, restoring gain")
+            }
+            sendspinManager.restoreVolume()
+        }
+    }
+
+    /**
+     * Whether any other app is playing something with an [INTERRUPTER_USAGES]
+     * usage. Emits the current answer on collection, then again on every playback
+     * configuration change.
+     */
+    private fun interrupterActive(): Flow<Boolean> = callbackFlow {
+        fun isActive(configs: List<android.media.AudioPlaybackConfiguration>) =
+            configs.any { it.audioAttributes.usage in INTERRUPTER_USAGES }
+
+        val callback = object : AudioManager.AudioPlaybackCallback() {
+            override fun onPlaybackConfigChanged(configs: MutableList<android.media.AudioPlaybackConfiguration>) {
+                trySend(isActive(configs))
+            }
+        }
+        audioManager.registerAudioPlaybackCallback(callback, null)
+        // Seed with the state at registration time, so a sound that started (or
+        // stopped) before we began listening is not waited for forever.
+        trySend(isActive(audioManager.activePlaybackConfigurations))
+        awaitClose { audioManager.unregisterAudioPlaybackCallback(callback) }
+    }.distinctUntilChanged()
 
     /**
      * Request audio focus for ANY output path (BT, speaker, Android Auto, wired…).


### PR DESCRIPTION
Music played at full volume over a ringing alarm, because the duck was released by a timer instead of by the alarm ending.

### What was wrong

`duck()` lowered our own Oboe gain and armed a ten second timer whose premise was that no `AUDIOFOCUS_GAIN` by then meant the GAIN had been dropped. That premise does not hold for any interruption longer than the timer. Measured against a real alarm on two phones:

| Interruption | GAIN arrived after | Timer fired early by |
|---|---|---|
| Samsung SM-S938B | 14.8 s | 4.8 s |
| Samsung SM-S938B | 4.4 s | did not fire, correct |
| Samsung SM-S938B | 16.4 s | 6.4 s |
| Samsung SM-S938B | 12.8 s | 2.8 s |
| Mi MIX 2S (Android 10) | 19.6 s | 9.6 s |

Four of five interruptions were longer than the timer. The focus events were never missing; the timer was second-guessing them.

The timer could not simply be deleted. It was added for a real case: an interrupter that takes transient focus and never returns it, where five of eleven ducks in one morning ran to the timeout.

### What changed

Android does report when another app's sound starts and stops, through `AudioManager.AudioPlaybackCallback`, and an app without `MODIFY_AUDIO_ROUTING` still sees other players' usage: `AudioPlaybackConfiguration.anonymizedCopy` keeps usage, content type and flags and strips only the identifiers.

The wait is now two phases, each with its own bound:

1. The interrupting sound has to appear, within ten seconds. If it never does we cannot observe it, so the gain is restored on that deadline, which preserves the original fix.
2. Then we wait for it to stop, under a generous cap.

A `AUDIOFOCUS_GAIN` at any point still cancels the wait and restores immediately. Both phases collect a freshly seeded flow, so the transition between them cannot be missed.

The release moved to `SendspinAudioController`, which owns focus policy and already holds an `AudioManager`, leaving `SendspinManager.duck()` as just the gain operation.

### Also in here

`resumeOrReassertPause` now supersedes itself. Moving `refresh()` off the `connectionState` collector in f3d92a3 left nothing to stop a second reconnect from refreshing the Sendspin transport while the first run's pause was still unconfirmed, which is the ordering that change exists to guarantee.

### Verification

Field-verified on the phone with a real alarm, 19.6 s interruption:

```
10:12:46.876  Audio focus lost transiently (no call): ducking
10:12:46.876  Duck -> 0.1 gain
10:13:06.520  Duck: interrupting sound ended, restoring gain
10:13:06.533  Audio focus gained
```

The duck held for the whole alarm and no `Duck safety timeout` fired. Our detection beat the platform's GAIN by 13 ms, which is expected: the sound stops before the alarm app abandons focus. The stream was untouched throughout, `underrun=0`, ring 2.5 to 2.7 s, `rate=1.00000`, no flush and no reopen.

detekt clean, 384 unit tests pass.

### Risk

No unit test: `SendspinAudioController` needs a `Context` and an `AudioManager` and is not unit-testable without a refactor, like the rest of that layer. The residual risk is a device whose alarm app plays as plain media rather than `USAGE_ALARM`, which cannot be observed; that falls back to the ten second deadline, which is the old behaviour, and the log says which path ran.
