### PR TITLE
Playlist detail: start Play All from the container, not the track list

### DIFF
--- a/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/PlaylistDetailViewModel.kt
+++ b/app/src/main/java/net/asksakis/massdroidv2/ui/screens/library/PlaylistDetailViewModel.kt
@@ -128,9 +128,16 @@ class PlaylistDetailViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Whether the listing has actually arrived, which is what tells an empty playlist
+     * apart from one that simply has not loaded yet. See [playWhole].
+     */
+    private var tracksLoaded = false
+
     private suspend fun loadTracks(forceRefresh: Boolean) {
         try {
             _rawTracks.value = musicRepository.getPlaylistTracks(itemId, provider, forceRefresh)
+            tracksLoaded = true
         } catch (e: Exception) {
             Log.w(TAG, "Load playlist tracks failed: ${e.message}")
         }
@@ -245,21 +252,35 @@ class PlaylistDetailViewModel @Inject constructor(
     /**
      * Send the whole playlist to the queue.
      *
-     * A dynamic playlist goes by its own URI so the server rebuilds it, which is the
-     * whole point of one and what playing it from the library list has always done.
-     * Everything else goes as the track list on screen, which is deliberate: this screen
-     * sorts and filters, and a static playlist should play in the order being looked at.
+     * The playlist goes as its own container URI whenever the list on screen is the
+     * server's own order (default sort, no favourites filter): the server then resolves
+     * the playlist in one paged pass and starts playback almost at once, the way playing
+     * it from the library list does. A dynamic playlist always goes this way so the
+     * server rebuilds it.
+     *
+     * Only once the user has re-sorted or filtered does it fall back to sending the
+     * explicit track list, so that what plays matches what is being looked at. That path
+     * makes the server resolve every track URI one by one, which for a large streaming
+     * playlist (Apple Music, ...) can take minutes before the first track starts.
      */
     private fun playWhole(option: String, what: String) {
         val queueId = playerRepository.requireSelectedPlayerId() ?: return
         val uris = tracks.value.map { it.uri }
+        val listedInServerOrder = sortKey.value == PlaylistSortKey.POSITION &&
+            !sortDescending.value &&
+            !_favoritesOnly.value
         // The URI is a navigation argument and can be absent; without it there is no
         // container to hand over and the track list is all there is, rebuild or not.
-        val rebuildOnServer = isDynamic && playlistUri.isNotBlank()
-        if (!rebuildOnServer && uris.isEmpty()) return
+        val useContainer = playlistUri.isNotBlank() && (isDynamic || listedInServerOrder)
+        // A playlist that has loaded and holds nothing has nothing to play, and must not
+        // replace what is already in the queue with emptiness. An empty list BEFORE the
+        // listing arrives means "not loaded yet", where the container is exactly the right
+        // thing to send; a dynamic playlist is drawn fresh by the server either way.
+        if (tracksLoaded && uris.isEmpty() && !isDynamic) return
+        if (!useContainer && uris.isEmpty()) return
         viewModelScope.launch {
             try {
-                if (rebuildOnServer) {
+                if (useContainer) {
                     musicRepository.playMedia(queueId, playlistUri, option = option)
                 } else {
                     musicRepository.playMedia(queueId, uris, option = option)


### PR DESCRIPTION
## Problem

On the playlist detail screen, **Play All** (and *Add to Queue* / *Play Next* / *Replace Queue*)
takes minutes to start on a large streaming playlist. On a ~300-track Apple Music playlist
served by MA 2.10 it was consistently over a minute before the first track began — long
enough that the button reads as broken.

Playing the *same* playlist by tapping it in the Library list has always started
almost immediately.

## Cause

`PlaylistDetailViewModel.playWhole()` sent `player_queues/play_media` an explicit list of
every track URI:

```kotlin
val uris = tracks.value.map { it.uri }
musicRepository.playMedia(queueId, uris, option = option)
```

Music Assistant resolves such a list one URI at a time against the provider, and playback
only starts once every entry has been resolved. For a streaming provider that is one HTTP
round trip per track.

The Library-list path (`LibraryViewModel.playPlaylist` → `playUri(playlist.uri)`) instead
hands over the playlist's own URI, and the server resolves the container in a single paged
pass — which is why that path was always fast.

## Fix

Send the container URI whenever the list on screen is still the server's own order —
default sort (`POSITION`, ascending) and no favourites filter — which is the state it is in
unless the user has deliberately changed it. Playback then starts in about two seconds.

The explicit track list is kept for exactly the case the original code was written for:
once the user has re-sorted or filtered, what plays should match what is on screen, and
only the track list can express that.

Dynamic playlists are unaffected — they already went by container URI so the server rebuilds
them (#67).

## Also in this change

An empty playlist no longer wipes the queue. The previous guard bailed out when the track
list was empty, but that guard does not cover the container path. An empty list means two
different things — *"this playlist is empty"* once the listing has arrived, and *"not loaded
yet"* before it has, where handing over the container is exactly right — so the view model
now tracks which of the two it is.

## Behaviour note worth flagging

On the container path, `MusicRepositoryImpl.playMedia(uri)` runs `preFilterBlocked`, which the
explicit-track-list overload does not. So for a user with blocked artists, Play All on a static
playlist now drops blocked-artist tracks where it previously kept them.

This looks like the desired outcome to me — it is what playing the playlist from the Library
list already does, and it is the point of blocking an artist — but it is a real change in what
the button queues, so flagging it rather than burying it. Happy to gate it if you'd rather keep
the old behaviour here.

## Testing

- `./gradlew :core:testDebugUnitTest :app:assembleGithubDebug detekt` — green, detekt reports 0 smells.
- Manually verified on an Echo Show 8 (LineageOS) against MA 2.10 with Apple Music:
  - ~300-track playlist, default sort → Play All starts after about two seconds,
    where the same playlist previously took minutes.
  - Re-sorted by Artist → falls back to the explicit track list, and the queue comes
    out in the on-screen order.
  - *Favorites only* filter → queues just the favourites.
  - Empty playlist → Play All does nothing, and a queue that was already playing keeps
    playing.
  - Blocked artist → their tracks are dropped from the queue (the behaviour note above).

Dynamic playlists are untouched by this patch — that branch resolves to the same
`playMedia(queueId, playlistUri, option)` call it made before, and the new empty-list
guard carries `&& !isDynamic` — so I have not listed it as separately tested.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
